### PR TITLE
feat: add support for pubsub/* HTTP endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,6 +1023,7 @@ dependencies = [
  "actix-multipart-rfc7578",
  "actix-web",
  "anyhow",
+ "async-stream",
  "async-trait",
  "dag-jose",
  "expect-test",
@@ -2730,7 +2731,7 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 [[package]]
 name = "iroh-api"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#c0918b22d70e590a4de865a58b87266202abe8e9"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2756,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "iroh-bitswap"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#c0918b22d70e590a4de865a58b87266202abe8e9"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -2794,7 +2795,7 @@ dependencies = [
 [[package]]
 name = "iroh-car"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#c0918b22d70e590a4de865a58b87266202abe8e9"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
 dependencies = [
  "cid 0.9.0",
  "futures",
@@ -2808,7 +2809,7 @@ dependencies = [
 [[package]]
 name = "iroh-embed"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#c0918b22d70e590a4de865a58b87266202abe8e9"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
 dependencies = [
  "anyhow",
  "futures",
@@ -2829,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "iroh-gateway"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#c0918b22d70e590a4de865a58b87266202abe8e9"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2889,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#c0918b22d70e590a4de865a58b87266202abe8e9"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
 dependencies = [
  "async-trait",
  "config",
@@ -2912,7 +2913,7 @@ dependencies = [
 [[package]]
 name = "iroh-one"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#c0918b22d70e590a4de865a58b87266202abe8e9"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2943,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "iroh-p2p"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#c0918b22d70e590a4de865a58b87266202abe8e9"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -2982,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "iroh-resolver"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#c0918b22d70e590a4de865a58b87266202abe8e9"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3008,7 +3009,7 @@ dependencies = [
 [[package]]
 name = "iroh-rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#c0918b22d70e590a4de865a58b87266202abe8e9"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3031,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "iroh-rpc-types"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#c0918b22d70e590a4de865a58b87266202abe8e9"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3049,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "iroh-store"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#c0918b22d70e590a4de865a58b87266202abe8e9"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3083,7 +3084,7 @@ dependencies = [
 [[package]]
 name = "iroh-unixfs"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#c0918b22d70e590a4de865a58b87266202abe8e9"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3120,7 +3121,7 @@ dependencies = [
 [[package]]
 name = "iroh-util"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#c0918b22d70e590a4de865a58b87266202abe8e9"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
 dependencies = [
  "anyhow",
  "cid 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = ["ceramic-kubo-rpc", "ceramic-one"]
 
 [workspace.dependencies]
 anyhow = "1"
+async-stream = "0.3"
 async-trait = "0.1"
 ceramic-one = { path = "./ceramic-one" }
 dag-jose = { git = "https://github.com/ceramicnetwork/rust-dag-jose", branch = "main" }

--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,4 @@ check-clippy:
 
 .PHONY: run
 run:
-	cargo run --all-features --locked --bin ceramic-one -- daemon -b 127.0.0.1:5001
+	RUST_LOG=ERROR,ceramic_kubo_rpc=DEBUG,ceramic_one=DEBUG cargo run --all-features --locked --bin ceramic-one -- daemon -b 127.0.0.1:5001

--- a/ceramic-kubo-rpc/Cargo.toml
+++ b/ceramic-kubo-rpc/Cargo.toml
@@ -23,6 +23,7 @@ actix-http = { version = "3", optional = true }
 actix-multipart = { version = "0.5", optional = true }
 actix-multipart-rfc7578 = { version = "0.9", optional = true }
 actix-web = { version = "4", optional = true }
+async-stream.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 dag-jose.workspace = true
@@ -40,6 +41,7 @@ tracing-actix-web = { version = "0.7", optional = true }
 tracing-opentelemetry.workspace = true
 tracing.workspace = true
 unimock.workspace = true
+hex = "0.4"
 
 [dev-dependencies]
 expect-test = "1"

--- a/ceramic-kubo-rpc/src/http/dag.rs
+++ b/ceramic-kubo-rpc/src/http/dag.rs
@@ -14,8 +14,8 @@ where
     T: IpfsDep + 'static,
 {
     web::scope("/dag")
-        .service(web::resource("/get").route(web::post().to(dag_get::<T>)))
-        .service(web::resource("/put").route(web::post().to(dag_put::<T>)))
+        .service(web::resource("/get").route(web::post().to(get::<T>)))
+        .service(web::resource("/put").route(web::post().to(put::<T>)))
         .service(web::resource("/resolve").route(web::post().to(resolve::<T>)))
 }
 
@@ -38,7 +38,7 @@ struct GetQuery {
 }
 
 #[tracing::instrument(skip(data))]
-async fn dag_get<T>(
+async fn get<T>(
     data: web::Data<AppState<T>>,
     query: web::Query<GetQuery>,
 ) -> Result<HttpResponse, Error>
@@ -69,7 +69,7 @@ struct PutQuery {
 }
 
 #[tracing::instrument(skip(data, payload))]
-async fn dag_put<T>(
+async fn put<T>(
     data: web::Data<AppState<T>>,
     query: web::Query<PutQuery>,
     mut payload: Multipart,

--- a/ceramic-kubo-rpc/src/http/pubsub.rs
+++ b/ceramic-kubo-rpc/src/http/pubsub.rs
@@ -1,0 +1,353 @@
+use crate::{error::Error, http::AppState, pubsub, IpfsDep};
+use actix_multipart::Multipart;
+use actix_web::{http::header::ContentType, web, HttpResponse, Scope};
+use anyhow::anyhow;
+use futures_util::StreamExt;
+use iroh_api::{Bytes, GossipsubEvent};
+use libipld::multibase::{self, Base};
+use libp2p::gossipsub::GossipsubMessage;
+use serde::{Deserialize, Serialize};
+
+pub fn scope<T>() -> Scope
+where
+    T: IpfsDep + 'static,
+{
+    web::scope("/pubsub")
+        .service(web::resource("/ls").route(web::post().to(list::<T>)))
+        .service(web::resource("/pub").route(web::post().to(publish::<T>)))
+        .service(web::resource("/sub").route(web::post().to(subscribe::<T>)))
+}
+
+#[tracing::instrument(skip(data))]
+async fn list<T>(data: web::Data<AppState<T>>) -> Result<HttpResponse, Error>
+where
+    T: IpfsDep,
+{
+    let topics = pubsub::topics(data.api.clone()).await?;
+
+    #[derive(Serialize)]
+    struct ListResponse {
+        #[serde(rename = "Strings")]
+        strings: Vec<String>,
+    }
+
+    let connect_resp = ListResponse { strings: topics };
+    let body = serde_json::to_vec(&connect_resp).map_err(|e| Error::Internal(e.into()))?;
+    Ok(HttpResponse::Ok()
+        .content_type(ContentType::json())
+        .body(body))
+}
+#[derive(Debug, Deserialize)]
+struct PublishQuery {
+    arg: String,
+}
+#[tracing::instrument(skip(data, payload))]
+async fn publish<T>(
+    data: web::Data<AppState<T>>,
+    query: web::Query<PublishQuery>,
+    mut payload: Multipart,
+) -> Result<HttpResponse, Error>
+where
+    T: IpfsDep,
+{
+    let (_base, topic_bytes) = multibase::decode(&query.arg).map_err(|e| {
+        Error::Internal(Into::<anyhow::Error>::into(e).context("decoding multibase topic"))
+    })?;
+    let topic = String::from_utf8(topic_bytes).map_err(|e| {
+        Error::Internal(Into::<anyhow::Error>::into(e).context("decoding topic as utf8 string"))
+    })?;
+    while let Some(item) = payload.next().await {
+        let mut field = item.map_err(|e| {
+            Error::Internal(Into::<anyhow::Error>::into(e).context("reading multipart field"))
+        })?;
+        if field.name() == "file" {
+            let mut input_bytes: Vec<u8> = Vec::new();
+            while let Some(chunk) = field.next().await {
+                input_bytes.extend(
+                    &chunk
+                        .map_err(|e| {
+                            Error::Internal(
+                                Into::<anyhow::Error>::into(e).context("reading multipart chunk"),
+                            )
+                        })?
+                        .to_vec(),
+                )
+            }
+
+            pubsub::publish(data.api.clone(), topic, input_bytes.into()).await?;
+            return Ok(HttpResponse::Ok().into());
+        }
+    }
+    Err(Error::Invalid(anyhow!("missing multipart field 'file'")))
+}
+#[derive(Debug, Deserialize)]
+struct SubscribeQuery {
+    arg: String,
+}
+#[tracing::instrument(skip(data))]
+async fn subscribe<T>(
+    data: web::Data<AppState<T>>,
+    query: web::Query<SubscribeQuery>,
+) -> Result<HttpResponse, Error>
+where
+    T: IpfsDep,
+{
+    let (_base, topic_bytes) = multibase::decode(&query.arg).map_err(|e| {
+        Error::Internal(Into::<anyhow::Error>::into(e).context("decoding multibase topic"))
+    })?;
+    let topic = String::from_utf8(topic_bytes).map_err(|e| {
+        Error::Internal(Into::<anyhow::Error>::into(e).context("decoding topic as utf8 string"))
+    })?;
+
+    let subscription = pubsub::subscribe(data.api.clone(), topic).await?;
+
+    #[derive(Serialize)]
+    struct MessageResponse {
+        from: String,
+        data: String,
+        seqno: String,
+        #[serde(rename = "topicIDs")]
+        topic_ids: Vec<String>,
+    }
+
+    Ok(HttpResponse::Ok().streaming(subscription.map(|event| {
+        event.map(|e| {
+            let m = match e {
+                // Ignore Subscribed and Unsubscribed events
+                GossipsubEvent::Subscribed { .. } | GossipsubEvent::Unsubscribed { .. } => {
+                    return Bytes::default()
+                }
+                GossipsubEvent::Message {
+                    from: _,
+                    id: _,
+                    message:
+                        GossipsubMessage {
+                            source,
+                            data,
+                            sequence_number,
+                            topic,
+                        },
+                } => MessageResponse {
+                    from: source.map(|p| p.to_string()).unwrap_or_default(),
+                    seqno: multibase::encode(
+                        Base::Base64Url,
+                        sequence_number
+                            .map(|seqno| seqno.to_le_bytes())
+                            .unwrap_or_default(),
+                    ),
+                    data: multibase::encode(Base::Base64Url, data),
+                    topic_ids: vec![multibase::encode(
+                        Base::Base64Url,
+                        topic.to_string().as_bytes(),
+                    )],
+                },
+            };
+            let mut data = serde_json::to_vec(&m).expect("gossip event should serialize to JSON");
+            data.push(b'\n');
+            data.into()
+        })
+    })))
+}
+#[cfg(test)]
+mod tests {
+
+    use std::io::Cursor;
+    use std::{collections::HashMap, str::FromStr};
+
+    use crate::{
+        error::Error,
+        http::tests::{assert_body_json, assert_body_json_nl, build_server},
+        IpfsDep,
+    };
+
+    use actix_multipart_rfc7578::client::multipart;
+    use actix_web::{body, test};
+    use anyhow::anyhow;
+    use async_stream::stream;
+    use async_trait::async_trait;
+    use expect_test::expect;
+    use futures_util::{stream::BoxStream, StreamExt};
+    use iroh_api::{Bytes, Cid, GossipsubEvent, IpfsPath, MessageId, Multiaddr, PeerId};
+    use libipld::multibase::{self, Base};
+    use libp2p::gossipsub::{GossipsubMessage, TopicHash};
+    use unimock::MockFn;
+    use unimock::{matching, Unimock};
+
+    use crate::IpfsDepMock;
+
+    #[actix_web::test]
+    async fn test_list() {
+        let mock = Unimock::new(
+            IpfsDepMock::topics
+                .some_call(matching!(_))
+                .returns(Ok(vec!["topicA".to_string(), "topicB".to_string()])),
+        );
+        let server = build_server(mock).await;
+        let req = test::TestRequest::post().uri("/pubsub/ls").to_request();
+        let resp = test::call_service(&server, req).await;
+        assert!(resp.status().is_success());
+        assert_eq!(
+            "application/json",
+            resp.headers().get("Content-Type").unwrap()
+        );
+        assert_body_json(
+            resp.into_body(),
+            expect![[r#"
+                {
+                  "Strings": [
+                    "topicA",
+                    "topicB"
+                  ]
+                }"#]],
+        )
+        .await;
+    }
+
+    #[actix_web::test]
+    async fn test_publish() {
+        let mock = Unimock::new(
+            IpfsDepMock::publish
+                .some_call(matching!((topic, _) if topic == "topicA"))
+                .returns(Ok(())),
+        );
+        let topic_arg = multibase::encode(Base::Base64Url, "topicA");
+
+        let mut form = multipart::Form::default();
+
+        let file_bytes = Cursor::new(r#"{"some":"json","bytes":false}"#);
+        form.add_reader_file("file", file_bytes, "");
+
+        let ct = form.content_type();
+        let body = body::to_bytes(multipart::Body::from(form)).await.unwrap();
+        let server = build_server(mock).await;
+        let req = test::TestRequest::post()
+            .uri(format!("/pubsub/pub?arg={}", topic_arg).as_str())
+            .insert_header(("Content-Type", ct))
+            .set_payload(body)
+            .to_request();
+        let resp = test::call_service(&server, req).await;
+        assert!(resp.status().is_success());
+    }
+
+    #[actix_web::test]
+    async fn test_subscribe() {
+        // Can't use unimock because it expects the stream to be Sync.
+        // So we create a one off implementation of the trait and only implement the method we
+        // need.
+        // Maybe we could make a macro for this?
+
+        #[derive(Clone)]
+        struct TestDeps {}
+        #[async_trait]
+        impl IpfsDep for TestDeps {
+            async fn get(&self, _ipfs_path: &IpfsPath) -> Result<(Cid, Bytes), Error> {
+                todo!()
+            }
+            async fn put(&self, _cid: Cid, _blob: Bytes, _links: Vec<Cid>) -> Result<(), Error> {
+                todo!()
+            }
+            async fn resolve(&self, _ipfs_path: &IpfsPath) -> Result<Vec<Cid>, Error> {
+                todo!()
+            }
+            async fn peers(&self) -> Result<HashMap<PeerId, Vec<Multiaddr>>, Error> {
+                todo!()
+            }
+            async fn connect(&self, _peer_id: PeerId, _addrs: Vec<Multiaddr>) -> Result<(), Error> {
+                todo!()
+            }
+            async fn publish(&self, _topic: String, _data: Bytes) -> Result<(), Error> {
+                todo!()
+            }
+            async fn subscribe(
+                &self,
+                topic: String,
+            ) -> Result<BoxStream<'static, anyhow::Result<GossipsubEvent>>, Error> {
+                if topic != "topicA" {
+                    return Err(Error::Internal(anyhow!("unexpected topic")));
+                }
+                let first = Ok(GossipsubEvent::Message {
+                    from: PeerId::from_str("12D3KooWHUfjwiTRVV8jxFcKRSQTPatayC4nQCNX86oxRF5XWzGe")
+                        .unwrap(),
+                    id: MessageId::new(&[]),
+                    message: GossipsubMessage {
+                        source: Some(
+                            PeerId::from_str(
+                                "12D3KooWM68GyFKBT9JsuTRB6CYkF61PtMuSkynUauSQEGBX51JW",
+                            )
+                            .unwrap(),
+                        ),
+                        data: "message 1".as_bytes().to_vec(),
+                        sequence_number: Some(0),
+                        topic: TopicHash::from_raw("topicA"),
+                    },
+                });
+                let second = Ok(GossipsubEvent::Message {
+                    from: PeerId::from_str("12D3KooWGnKwtpSh2ZLTvoC8mjiexMNRLNkT92pxq7MDgyJHktNJ")
+                        .unwrap(),
+                    id: MessageId::new(&[]),
+                    message: GossipsubMessage {
+                        source: Some(
+                            PeerId::from_str(
+                                "12D3KooWQVU9Pv3BqD6bD9w96tJxLedKCj4VZ75oqX9Tav4R4rUS",
+                            )
+                            .unwrap(),
+                        ),
+                        data: "message 2".as_bytes().to_vec(),
+                        sequence_number: Some(1),
+                        topic: TopicHash::from_raw("topicA"),
+                    },
+                });
+
+                Ok(stream! {
+                    yield first;
+                    yield second;
+                }
+                .boxed())
+            }
+            async fn topics(&self) -> Result<Vec<String>, Error> {
+                todo!()
+            }
+        }
+
+        let mock = TestDeps {};
+        let topic_arg = multibase::encode(Base::Base64Url, "topicA");
+
+        let mut form = multipart::Form::default();
+
+        let file_bytes = Cursor::new(r#"{"some":"json","bytes":false}"#);
+        form.add_reader_file("file", file_bytes, "");
+
+        let ct = form.content_type();
+        let body = body::to_bytes(multipart::Body::from(form)).await.unwrap();
+        let server = build_server(mock).await;
+        let req = test::TestRequest::post()
+            .uri(format!("/pubsub/sub?arg={}", topic_arg).as_str())
+            .insert_header(("Content-Type", ct))
+            .set_payload(body)
+            .to_request();
+        let resp = test::call_service(&server, req).await;
+        assert!(resp.status().is_success());
+        assert_body_json_nl(
+            resp.into_body(),
+            expect![[r#"
+                {
+                  "data": "ubWVzc2FnZSAx",
+                  "from": "12D3KooWM68GyFKBT9JsuTRB6CYkF61PtMuSkynUauSQEGBX51JW",
+                  "seqno": "uAAAAAAAAAAA",
+                  "topicIDs": [
+                    "udG9waWNB"
+                  ]
+                }
+                {
+                  "data": "ubWVzc2FnZSAy",
+                  "from": "12D3KooWQVU9Pv3BqD6bD9w96tJxLedKCj4VZ75oqX9Tav4R4rUS",
+                  "seqno": "uAQAAAAAAAAA",
+                  "topicIDs": [
+                    "udG9waWNB"
+                  ]
+                }
+            "#]],
+        )
+        .await;
+    }
+}

--- a/ceramic-kubo-rpc/src/http/swarm.rs
+++ b/ceramic-kubo-rpc/src/http/swarm.rs
@@ -13,12 +13,12 @@ where
     T: IpfsDep + 'static,
 {
     web::scope("/swarm")
-        .service(web::resource("/peers").route(web::post().to(swarm_peers::<T>)))
-        .service(web::resource("/connect").route(web::post().to(swarm_connect::<T>)))
+        .service(web::resource("/peers").route(web::post().to(peers::<T>)))
+        .service(web::resource("/connect").route(web::post().to(connect::<T>)))
 }
 
 #[tracing::instrument(skip(data))]
-async fn swarm_peers<T>(data: web::Data<AppState<T>>) -> Result<HttpResponse, Error>
+async fn peers<T>(data: web::Data<AppState<T>>) -> Result<HttpResponse, Error>
 where
     T: IpfsDep,
 {
@@ -70,7 +70,7 @@ struct ConnectQuery {
 }
 
 #[tracing::instrument(skip(data))]
-async fn swarm_connect<T>(
+async fn connect<T>(
     data: web::Data<AppState<T>>,
     query: web::Query<ConnectQuery>,
 ) -> Result<HttpResponse, Error>

--- a/ceramic-kubo-rpc/src/pubsub.rs
+++ b/ceramic-kubo-rpc/src/pubsub.rs
@@ -1,0 +1,35 @@
+//! Publish Subscribe API
+
+use futures_util::stream::BoxStream;
+use iroh_api::{Bytes, GossipsubEvent};
+
+use crate::{error::Error, IpfsDep};
+
+/// Publish a message to a topic
+#[tracing::instrument(skip(client, data))]
+pub async fn publish<T>(client: T, topic: String, data: Bytes) -> Result<(), Error>
+where
+    T: IpfsDep,
+{
+    client.publish(topic, data).await?;
+    Ok(())
+}
+/// Subscribe to a topic returning a stream of messages from that topic
+#[tracing::instrument(skip(client))]
+pub async fn subscribe<T>(
+    client: T,
+    topic: String,
+) -> Result<BoxStream<'static, anyhow::Result<GossipsubEvent>>, Error>
+where
+    T: IpfsDep,
+{
+    client.subscribe(topic).await
+}
+/// Returns a list of topics, to which we are currently subscribed.
+#[tracing::instrument(skip(client))]
+pub async fn topics<T>(client: T) -> Result<Vec<String>, Error>
+where
+    T: IpfsDep,
+{
+    client.topics().await
+}


### PR DESCRIPTION
With this change the RPC implements listing subscribed topics and publishing/subscribing  messages to/from topics.