### PR TITLE
feat: adds id endpoint and adds dag-jose resolving support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,7 @@ dependencies = [
  "names",
  "opentelemetry",
  "opentelemetry-otlp",
+ "tempdir",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -2073,6 +2074,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "futures"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,7 +2740,7 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 [[package]]
 name = "iroh-api"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2759,7 +2766,7 @@ dependencies = [
 [[package]]
 name = "iroh-bitswap"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -2797,7 +2804,7 @@ dependencies = [
 [[package]]
 name = "iroh-car"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
 dependencies = [
  "cid 0.9.0",
  "futures",
@@ -2811,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "iroh-embed"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
 dependencies = [
  "anyhow",
  "futures",
@@ -2832,7 +2839,7 @@ dependencies = [
 [[package]]
 name = "iroh-gateway"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2892,7 +2899,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
 dependencies = [
  "async-trait",
  "config",
@@ -2915,7 +2922,7 @@ dependencies = [
 [[package]]
 name = "iroh-one"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2946,7 +2953,7 @@ dependencies = [
 [[package]]
 name = "iroh-p2p"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -2985,7 +2992,7 @@ dependencies = [
 [[package]]
 name = "iroh-resolver"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3011,7 +3018,7 @@ dependencies = [
 [[package]]
 name = "iroh-rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3034,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "iroh-rpc-types"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3052,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "iroh-store"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3086,7 +3093,7 @@ dependencies = [
 [[package]]
 name = "iroh-unixfs"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3123,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "iroh-util"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#84335ac67b5bce9e1c103d052ed5c3c5e3514833"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
 dependencies = [
  "anyhow",
  "cid 0.9.0",
@@ -5144,6 +5151,19 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -5185,6 +5205,21 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -5261,6 +5296,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5311,6 +5355,15 @@ name = "relative-path"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "rend"
@@ -6165,6 +6218,16 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]

--- a/ceramic-kubo-rpc/src/http/dag.rs
+++ b/ceramic-kubo-rpc/src/http/dag.rs
@@ -3,6 +3,7 @@ use std::{io::Cursor, str::FromStr};
 use actix_multipart::Multipart;
 use actix_web::{http::header::ContentType, web, HttpResponse, Scope};
 use anyhow::anyhow;
+use dag_jose::DagJoseCodec;
 use futures_util::StreamExt;
 use iroh_api::IpfsPath;
 use libipld::{cbor::DagCborCodec, ipld, json::DagJsonCodec, prelude::Encode};
@@ -11,7 +12,7 @@ use serde::Deserialize;
 use crate::{
     dag,
     error::Error,
-    http::{AppState, DAG_CBOR, DAG_JSON},
+    http::{AppState, DAG_CBOR, DAG_JOSE, DAG_JSON},
     IpfsDep,
 };
 pub fn scope<T>() -> Scope
@@ -79,10 +80,12 @@ async fn put<T>(
 where
     T: IpfsDep,
 {
+    let mut fields = Vec::new();
     while let Some(item) = payload.next().await {
         let mut field = item.map_err(|e| {
             Error::Internal(Into::<anyhow::Error>::into(e).context("reading multipart field"))
         })?;
+        fields.push(field.name().to_owned());
         if field.name() == "file" {
             let mut input_bytes: Vec<u8> = Vec::new();
             while let Some(chunk) = field.next().await {
@@ -107,6 +110,24 @@ where
                     )
                     .await?
                 }
+                (DAG_CBOR, DAG_CBOR) => {
+                    dag::put(
+                        data.api.clone(),
+                        DagCborCodec,
+                        DagCborCodec,
+                        &mut Cursor::new(input_bytes),
+                    )
+                    .await?
+                }
+                (DAG_JOSE, DAG_JOSE) => {
+                    dag::put(
+                        data.api.clone(),
+                        DagJoseCodec,
+                        DagJoseCodec,
+                        &mut Cursor::new(input_bytes),
+                    )
+                    .await?
+                }
                 _ => {
                     return Err(Error::Invalid(anyhow!(
                         "unsupported input-codec, store-codec combination \"{}\", \"{}\"",
@@ -127,7 +148,10 @@ where
                 .body(data));
         }
     }
-    Err(Error::Invalid(anyhow!("missing multipart field 'file'")))
+    Err(Error::Invalid(anyhow!(
+        "dag put: missing multipart field 'file' found fields: {:?}",
+        fields
+    )))
 }
 
 #[derive(Debug, Deserialize)]
@@ -144,11 +168,10 @@ where
     T: IpfsDep,
 {
     let path: IpfsPath = query.arg.parse().map_err(Error::Invalid)?;
-    let cid = dag::resolve(data.api.clone(), &path).await?;
+    let (cid, remaining_path) = dag::resolve(data.api.clone(), &path).await?;
     let resolved = ipld!({
         "Cid": cid,
-        // TODO(nathanielc): What is this? Do we use it?
-        "RemPath": "",
+        "RemPath": remaining_path,
     });
 
     let mut data = Vec::new();
@@ -168,22 +191,25 @@ mod tests {
     use actix_multipart_rfc7578::client::multipart;
     use actix_web::{body, test};
     use expect_test::expect;
-    use iroh_api::{Bytes, Cid};
+    use iroh_api::Cid;
+    use libipld::{pb::DagPbCodec, prelude::Decode, Ipld};
     use unimock::MockFn;
     use unimock::{matching, Unimock};
 
     use crate::IpfsDepMock;
 
     #[actix_web::test]
-    async fn test_dag_get_json() {
+    async fn test_get_json() {
         // Test data from:
         // https://ipld.io/specs/codecs/dag-pb/fixtures/cross-codec/#dagpb_data_some
-        let bytes: Bytes = hex::decode("0a050001020304")
-            .expect("should be valid hex data")
-            .into();
+        let data = Ipld::decode(
+            DagPbCodec,
+            &mut Cursor::new(hex::decode("0a050001020304").expect("should be valid hex data")),
+        )
+        .expect("should be valid dag-pb data");
         let mock = Unimock::new(IpfsDepMock::get.some_call(matching!(_)).returns(Ok((
             Cid::try_from("bafybeibazl2z4vqp2tmwcfag6wirmtpnomxknqcgrauj7m2yisrz3qjbom").unwrap(),
-            bytes,
+            data,
         ))));
         let server = build_server(mock).await;
         let req = test::TestRequest::post()
@@ -211,15 +237,17 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn test_dag_get_cbor() {
+    async fn test_get_cbor() {
         // Test data from:
         // https://ipld.io/specs/codecs/dag-pb/fixtures/cross-codec/#dagpb_data_some
-        let bytes: Bytes = hex::decode("0a050001020304")
-            .expect("should be valid hex data")
-            .into();
+        let data = Ipld::decode(
+            DagPbCodec,
+            &mut Cursor::new(hex::decode("0a050001020304").expect("should be valid hex data")),
+        )
+        .expect("should be valid dag-pb data");
         let mock = Unimock::new(IpfsDepMock::get.some_call(matching!(_)).returns(Ok((
             Cid::try_from("bafybeibazl2z4vqp2tmwcfag6wirmtpnomxknqcgrauj7m2yisrz3qjbom").unwrap(),
-            bytes,
+            data,
         ))));
         let server = build_server(mock).await;
         let req = test::TestRequest::post()
@@ -239,7 +267,7 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn test_dag_put() {
+    async fn test_put() {
         // Test data from:
         // https://ipld.io/specs/codecs/dag-json/fixtures/cross-codec/#array-mixed
         let mock = Unimock::new(
@@ -284,13 +312,13 @@ mod tests {
         .await;
     }
     #[actix_web::test]
-    async fn test_dag_resolve() {
+    async fn test_resolve() {
         // Test data uses getting started guide for IPFS:
         // ipfs://QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc
         let mock = Unimock::new(
             IpfsDepMock::resolve
                 .next_call(matching!((p) if **p == IpfsPath::from_str("QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/ping").unwrap()))
-                .returns(Ok(vec![Cid::from_str("QmejvEPop4D7YUadeGqYWmZxHhLc4JBUCzJJHWMzdcMe2y").unwrap()])),
+                .returns(Ok((Cid::from_str("QmejvEPop4D7YUadeGqYWmZxHhLc4JBUCzJJHWMzdcMe2y").unwrap(),"".to_string()))),
         );
         let server = build_server(mock).await;
         let req = test::TestRequest::post()
@@ -310,6 +338,35 @@ mod tests {
                     "/": "QmejvEPop4D7YUadeGqYWmZxHhLc4JBUCzJJHWMzdcMe2y"
                   },
                   "RemPath": ""
+                }"#]],
+        )
+        .await;
+    }
+    #[actix_web::test]
+    async fn test_resolve_remaining() {
+        let mock = Unimock::new(
+            IpfsDepMock::resolve
+                .next_call(matching!((p) if **p == IpfsPath::from_str("bafyreih6aqnl3v2d6jlidqqnw6skf2ntrtswvra65xz73ymrqspdy2jfai/chainId").unwrap()))
+                .returns(Ok((Cid::from_str("bafyreih6aqnl3v2d6jlidqqnw6skf2ntrtswvra65xz73ymrqspdy2jfai").unwrap(),"chainId".to_string()))),
+        );
+        let server = build_server(mock).await;
+        let req = test::TestRequest::post()
+            .uri("/dag/resolve?arg=bafyreih6aqnl3v2d6jlidqqnw6skf2ntrtswvra65xz73ymrqspdy2jfai/chainId")
+            .to_request();
+        let resp = test::call_service(&server, req).await;
+        assert!(resp.status().is_success());
+        assert_eq!(
+            "application/json",
+            resp.headers().get("Content-Type").unwrap()
+        );
+        assert_body_json(
+            resp.into_body(),
+            expect![[r#"
+                {
+                  "Cid": {
+                    "/": "bafyreih6aqnl3v2d6jlidqqnw6skf2ntrtswvra65xz73ymrqspdy2jfai"
+                  },
+                  "RemPath": "chainId"
                 }"#]],
         )
         .await;

--- a/ceramic-kubo-rpc/src/http/id.rs
+++ b/ceramic-kubo-rpc/src/http/id.rs
@@ -28,14 +28,14 @@ async fn id<T>(
 where
     T: IpfsDep,
 {
-    if let Some(_) = query.format {
+    if query.format.is_some() {
         return Err(Error::Invalid(anyhow!("format is not supported.")));
     }
-    if let Some(_) = query.peer_id_base {
+    if query.peer_id_base.is_some() {
         return Err(Error::Invalid(anyhow!("peerid-base is not supported.")));
     }
     let info = if let Some(id) = &query.arg {
-        let peer_id = PeerId::from_str(&id).map_err(|e| Error::Invalid(e.into()))?;
+        let peer_id = PeerId::from_str(id).map_err(|e| Error::Invalid(e.into()))?;
         id::lookup(data.api.clone(), peer_id).await?
     } else {
         id::lookup_local(data.api.clone()).await?

--- a/ceramic-kubo-rpc/src/http/id.rs
+++ b/ceramic-kubo-rpc/src/http/id.rs
@@ -1,0 +1,237 @@
+use std::str::FromStr;
+
+use actix_web::{http::header::ContentType, web, HttpResponse, Scope};
+use anyhow::anyhow;
+use iroh_api::PeerId;
+use serde::{Deserialize, Serialize};
+
+use crate::{error::Error, http::AppState, id, IpfsDep};
+pub fn scope<T>() -> Scope
+where
+    T: IpfsDep + 'static,
+{
+    web::scope("/id").route("", web::post().to(id::<T>))
+}
+#[derive(Debug, Deserialize)]
+struct IdQuery {
+    arg: Option<String>,
+    format: Option<String>,
+    #[serde(rename = "peerid-base")]
+    peer_id_base: Option<String>,
+}
+
+#[tracing::instrument(skip(data))]
+async fn id<T>(
+    data: web::Data<AppState<T>>,
+    query: web::Query<IdQuery>,
+) -> Result<HttpResponse, Error>
+where
+    T: IpfsDep,
+{
+    if let Some(_) = query.format {
+        return Err(Error::Invalid(anyhow!("format is not supported.")));
+    }
+    if let Some(_) = query.peer_id_base {
+        return Err(Error::Invalid(anyhow!("peerid-base is not supported.")));
+    }
+    let info = if let Some(id) = &query.arg {
+        let peer_id = PeerId::from_str(&id).map_err(|e| Error::Invalid(e.into()))?;
+        id::lookup(data.api.clone(), peer_id).await?
+    } else {
+        id::lookup_local(data.api.clone()).await?
+    };
+    #[derive(Serialize)]
+    struct IdResponse {
+        #[serde(rename = "ID")]
+        id: String,
+        #[serde(rename = "Addresses")]
+        addresses: Vec<String>,
+        #[serde(rename = "AgentVersion")]
+        agent_version: String,
+        #[serde(rename = "ProtocolVersion")]
+        protocol_version: String,
+        #[serde(rename = "Protocols")]
+        protocols: Vec<String>,
+    }
+    let id = IdResponse {
+        id: info.peer_id.to_string(),
+        addresses: info
+            .listen_addrs
+            .into_iter()
+            .map(|a| a.to_string())
+            .collect(),
+        agent_version: info.agent_version,
+        protocol_version: info.protocol_version,
+        protocols: info.protocols,
+    };
+    let body = serde_json::to_vec(&id).map_err(|e| Error::Internal(e.into()))?;
+    Ok(HttpResponse::Ok()
+        .content_type(ContentType::json())
+        .body(body))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    use crate::http::tests::{assert_body_json, build_server};
+    use crate::PeerInfo;
+
+    use actix_web::test;
+    use expect_test::expect;
+    use unimock::MockFn;
+    use unimock::{matching, Unimock};
+
+    use crate::IpfsDepMock;
+
+    #[actix_web::test]
+    async fn test_id() {
+        let info = PeerInfo {
+            peer_id: "12D3KooWQuKj4A11GNZ4MmcAmJzCNGZjArjyRTgkLhSutqeqVypv"
+                .parse()
+                .unwrap(),
+            protocol_version: "ipfs/0.1.0".to_string(),
+            agent_version: "iroh/0.2.0".to_string(),
+            listen_addrs: vec![
+                "/ip4/127.0.0.1/udp/35826/quic-v1".parse().unwrap(),
+                "/ip4/192.168.12.189/tcp/43113".parse().unwrap(),
+            ],
+            protocols: vec![
+                "/ipfs/ping/1.0.0".parse().unwrap(),
+                "/ipfs/id/1.0.0".parse().unwrap(),
+                "/ipfs/id/push/1.0.0".parse().unwrap(),
+                "/ipfs/bitswap/1.2.0".parse().unwrap(),
+                "/ipfs/bitswap/1.1.0".parse().unwrap(),
+                "/ipfs/bitswap/1.0.0".parse().unwrap(),
+                "/ipfs/bitswap".parse().unwrap(),
+                "/ipfs/kad/1.0.0".parse().unwrap(),
+                "/libp2p/autonat/1.0.0".parse().unwrap(),
+                "/libp2p/circuit/relay/0.2.0/hop".parse().unwrap(),
+                "/libp2p/circuit/relay/0.2.0/stop".parse().unwrap(),
+                "/libp2p/dcutr".parse().unwrap(),
+                "/meshsub/1.1.0".parse().unwrap(),
+                "/meshsub/1.0.0".parse().unwrap(),
+            ],
+        };
+        let mock = Unimock::new(
+            IpfsDepMock::lookup
+                .some_call(matching!((p) if p == &PeerId::from_str("12D3KooWQuKj4A11GNZ4MmcAmJzCNGZjArjyRTgkLhSutqeqVypv").unwrap()))
+                .returns(Ok(info)),
+        );
+        let server = build_server(mock).await;
+        let req = test::TestRequest::post()
+            .uri("/id?arg=12D3KooWQuKj4A11GNZ4MmcAmJzCNGZjArjyRTgkLhSutqeqVypv")
+            .to_request();
+        let resp = test::call_service(&server, req).await;
+        assert!(resp.status().is_success());
+        assert_eq!(
+            "application/json",
+            resp.headers().get("Content-Type").unwrap()
+        );
+        assert_body_json(
+            resp.into_body(),
+            expect![[r#"
+                {
+                  "Addresses": [
+                    "/ip4/127.0.0.1/udp/35826/quic-v1",
+                    "/ip4/192.168.12.189/tcp/43113"
+                  ],
+                  "AgentVersion": "iroh/0.2.0",
+                  "ID": "12D3KooWQuKj4A11GNZ4MmcAmJzCNGZjArjyRTgkLhSutqeqVypv",
+                  "ProtocolVersion": "ipfs/0.1.0",
+                  "Protocols": [
+                    "/ipfs/ping/1.0.0",
+                    "/ipfs/id/1.0.0",
+                    "/ipfs/id/push/1.0.0",
+                    "/ipfs/bitswap/1.2.0",
+                    "/ipfs/bitswap/1.1.0",
+                    "/ipfs/bitswap/1.0.0",
+                    "/ipfs/bitswap",
+                    "/ipfs/kad/1.0.0",
+                    "/libp2p/autonat/1.0.0",
+                    "/libp2p/circuit/relay/0.2.0/hop",
+                    "/libp2p/circuit/relay/0.2.0/stop",
+                    "/libp2p/dcutr",
+                    "/meshsub/1.1.0",
+                    "/meshsub/1.0.0"
+                  ]
+                }"#]],
+        )
+        .await;
+    }
+
+    #[actix_web::test]
+    async fn test_local_id() {
+        let info = PeerInfo {
+            peer_id: "12D3KooWQuKj4A11GNZ4MmcAmJzCNGZjArjyRTgkLhSutqeqVypv"
+                .parse()
+                .unwrap(),
+            protocol_version: "ipfs/0.1.0".to_string(),
+            agent_version: "iroh/0.2.0".to_string(),
+            listen_addrs: vec![
+                "/ip4/127.0.0.1/udp/35826/quic-v1".parse().unwrap(),
+                "/ip4/192.168.12.189/tcp/43113".parse().unwrap(),
+            ],
+            protocols: vec![
+                "/ipfs/ping/1.0.0".parse().unwrap(),
+                "/ipfs/id/1.0.0".parse().unwrap(),
+                "/ipfs/id/push/1.0.0".parse().unwrap(),
+                "/ipfs/bitswap/1.2.0".parse().unwrap(),
+                "/ipfs/bitswap/1.1.0".parse().unwrap(),
+                "/ipfs/bitswap/1.0.0".parse().unwrap(),
+                "/ipfs/bitswap".parse().unwrap(),
+                "/ipfs/kad/1.0.0".parse().unwrap(),
+                "/libp2p/autonat/1.0.0".parse().unwrap(),
+                "/libp2p/circuit/relay/0.2.0/hop".parse().unwrap(),
+                "/libp2p/circuit/relay/0.2.0/stop".parse().unwrap(),
+                "/libp2p/dcutr".parse().unwrap(),
+                "/meshsub/1.1.0".parse().unwrap(),
+                "/meshsub/1.0.0".parse().unwrap(),
+            ],
+        };
+        let mock = Unimock::new(
+            IpfsDepMock::lookup_local
+                .some_call(matching!(_))
+                .returns(Ok(info)),
+        );
+        let server = build_server(mock).await;
+        let req = test::TestRequest::post().uri("/id").to_request();
+        let resp = test::call_service(&server, req).await;
+        assert!(resp.status().is_success());
+        assert_eq!(
+            "application/json",
+            resp.headers().get("Content-Type").unwrap()
+        );
+        assert_body_json(
+            resp.into_body(),
+            expect![[r#"
+                {
+                  "Addresses": [
+                    "/ip4/127.0.0.1/udp/35826/quic-v1",
+                    "/ip4/192.168.12.189/tcp/43113"
+                  ],
+                  "AgentVersion": "iroh/0.2.0",
+                  "ID": "12D3KooWQuKj4A11GNZ4MmcAmJzCNGZjArjyRTgkLhSutqeqVypv",
+                  "ProtocolVersion": "ipfs/0.1.0",
+                  "Protocols": [
+                    "/ipfs/ping/1.0.0",
+                    "/ipfs/id/1.0.0",
+                    "/ipfs/id/push/1.0.0",
+                    "/ipfs/bitswap/1.2.0",
+                    "/ipfs/bitswap/1.1.0",
+                    "/ipfs/bitswap/1.0.0",
+                    "/ipfs/bitswap",
+                    "/ipfs/kad/1.0.0",
+                    "/libp2p/autonat/1.0.0",
+                    "/libp2p/circuit/relay/0.2.0/hop",
+                    "/libp2p/circuit/relay/0.2.0/stop",
+                    "/libp2p/dcutr",
+                    "/meshsub/1.1.0",
+                    "/meshsub/1.0.0"
+                  ]
+                }"#]],
+        )
+        .await;
+    }
+}

--- a/ceramic-kubo-rpc/src/http/mod.rs
+++ b/ceramic-kubo-rpc/src/http/mod.rs
@@ -13,6 +13,7 @@ use crate::{error::Error, IpfsDep};
 
 mod block;
 mod dag;
+mod id;
 mod pin;
 mod pubsub;
 mod swarm;
@@ -50,6 +51,7 @@ where
                 web::scope("/api/v0")
                     .service(block::scope::<T>())
                     .service(dag::scope::<T>())
+                    .service(id::scope::<T>())
                     .service(pin::scope::<T>())
                     .service(pubsub::scope::<T>())
                     .service(swarm::scope::<T>()),
@@ -121,6 +123,7 @@ mod tests {
                 .app_data(web::Data::new(AppState { api: mock }))
                 .service(super::block::scope::<T>())
                 .service(super::dag::scope::<T>())
+                .service(id::scope::<T>())
                 .service(super::pin::scope::<T>())
                 .service(super::pubsub::scope::<T>())
                 .service(super::swarm::scope::<T>()),

--- a/ceramic-kubo-rpc/src/id.rs
+++ b/ceramic-kubo-rpc/src/id.rs
@@ -1,0 +1,20 @@
+//! Provides methods for looking up peer info.
+use iroh_api::PeerId;
+
+use crate::{error::Error, IpfsDep, PeerInfo};
+
+/// Lookup information about a specific peer.
+#[tracing::instrument(skip(client))]
+pub async fn lookup<T>(client: T, peer_id: PeerId) -> Result<PeerInfo, Error>
+where
+    T: IpfsDep,
+{
+    client.lookup(peer_id).await
+}
+/// Lookup information about the local peer.
+pub async fn lookup_local<T>(client: T) -> Result<PeerInfo, Error>
+where
+    T: IpfsDep,
+{
+    client.lookup_local().await
+}

--- a/ceramic-kubo-rpc/src/lib.rs
+++ b/ceramic-kubo-rpc/src/lib.rs
@@ -6,12 +6,14 @@
 //! The http server implementation is behind the `http` feature.
 #![deny(warnings)]
 #![deny(missing_docs)]
-use std::collections::HashMap;
+use std::{collections::HashMap, io::Cursor, path::PathBuf};
 
 use anyhow::anyhow;
 use async_trait::async_trait;
+use dag_jose::DagJoseCodec;
 use futures_util::stream::BoxStream;
 use iroh_api::{Api, Bytes, Cid, GossipsubEvent, IpfsPath, Multiaddr, PeerId};
+use libipld::{cbor::DagCborCodec, json::DagJsonCodec, prelude::Decode, Ipld};
 use unimock::unimock;
 
 pub mod block;
@@ -19,11 +21,27 @@ pub mod dag;
 pub mod error;
 #[cfg(feature = "http")]
 pub mod http;
+pub mod id;
 pub mod pin;
 pub mod pubsub;
 pub mod swarm;
 
 use crate::error::Error;
+
+/// Information about a peer
+#[derive(Debug)]
+pub struct PeerInfo {
+    /// Id of the peer.
+    pub peer_id: PeerId,
+    /// Protocol version of the peer.
+    pub protocol_version: String,
+    /// Agent version of the peer.
+    pub agent_version: String,
+    /// Publish listening address of the peer.
+    pub listen_addrs: Vec<Multiaddr>,
+    /// Protocols supported by the peer.
+    pub protocols: Vec<String>,
+}
 
 /// Defines the behavior this crate needs from IPFS in order to serve Kubo RPC calls.
 /// The trait serves two purposes:
@@ -32,17 +50,21 @@ use crate::error::Error;
 #[unimock(api=IpfsDepMock)]
 #[async_trait]
 pub trait IpfsDep: Clone {
+    /// Get information about the local peer.
+    async fn lookup_local(&self) -> Result<PeerInfo, Error>;
+    /// Get information about a peer.
+    async fn lookup(&self, peer_id: PeerId) -> Result<PeerInfo, Error>;
     /// Get the size of an IPFS block.
     async fn block_size(&self, cid: Cid) -> Result<u64, Error>;
     /// Get a block from IPFS
     async fn block_get(&self, cid: Cid) -> Result<Bytes, Error>;
     /// Get a DAG node from IPFS returning the Cid of the resolved path and the bytes of the node.
     /// This will locally store the data as a result.
-    async fn get(&self, ipfs_path: &IpfsPath) -> Result<(Cid, Bytes), Error>;
+    async fn get(&self, ipfs_path: &IpfsPath) -> Result<(Cid, Ipld), Error>;
     /// Store a DAG node into IFPS.
     async fn put(&self, cid: Cid, blob: Bytes, links: Vec<Cid>) -> Result<(), Error>;
     /// Resolve an IPLD block.
-    async fn resolve(&self, ipfs_path: &IpfsPath) -> Result<Vec<Cid>, Error>;
+    async fn resolve(&self, ipfs_path: &IpfsPath) -> Result<(Cid, String), Error>;
     /// Report all connected peers of the current node.
     async fn peers(&self) -> Result<HashMap<PeerId, Vec<Multiaddr>>, Error>;
     /// Connect to a specific peer node.
@@ -60,6 +82,40 @@ pub trait IpfsDep: Clone {
 
 #[async_trait]
 impl IpfsDep for Api {
+    /// Get the ID of the local peer.
+    async fn lookup_local(&self) -> Result<PeerInfo, Error> {
+        let l = self
+            .client()
+            .try_p2p()
+            .map_err(Error::Internal)?
+            .lookup_local()
+            .await
+            .map_err(Error::Internal)?;
+        Ok(PeerInfo {
+            peer_id: l.peer_id,
+            protocol_version: l.protocol_version,
+            agent_version: l.agent_version,
+            listen_addrs: l.listen_addrs,
+            protocols: l.protocols,
+        })
+    }
+    /// Get information a peer.
+    async fn lookup(&self, peer_id: PeerId) -> Result<PeerInfo, Error> {
+        let l = self
+            .client()
+            .try_p2p()
+            .map_err(Error::Internal)?
+            .lookup(peer_id, None)
+            .await
+            .map_err(Error::Internal)?;
+        Ok(PeerInfo {
+            peer_id: l.peer_id,
+            protocol_version: l.protocol_version,
+            agent_version: l.agent_version,
+            listen_addrs: l.listen_addrs,
+            protocols: l.protocols,
+        })
+    }
     async fn block_size(&self, cid: Cid) -> Result<u64, Error> {
         Ok(self
             .client()
@@ -71,33 +127,23 @@ impl IpfsDep for Api {
             .ok_or(Error::NotFound)?)
     }
     async fn block_get(&self, cid: Cid) -> Result<Bytes, Error> {
-        Ok(self
-            .client()
-            .try_store()
-            .map_err(Error::Internal)?
-            .get(cid)
-            .await
-            .map_err(Error::Internal)?
-            .ok_or(Error::NotFound)?)
+        Ok(self.get_raw(cid).await.map_err(Error::Internal)?)
     }
-    async fn get(&self, ipfs_path: &IpfsPath) -> Result<(Cid, Bytes), Error> {
-        // TODO(nathanielc): Iroh does not have support for DAG-JOSE,
-        // therefore it cannot traverse paths as it cannot decode the intermediate steps.
-        // We use `get_raw` below so that we can still get the data but as a result we do not support
-        // any path below the Cid.
-        if !ipfs_path.tail().is_empty() {
-            return Err(Error::Invalid(anyhow!(
-                "IPFS paths with path elements are not yet supported"
-            )));
-        }
-
-        if let Some(cid) = ipfs_path.cid() {
-            Ok((*cid, self.get_raw(*cid).await.map_err(Error::Internal)?))
-        } else {
-            Err(Error::Invalid(anyhow!("IPFS path does not refer to a CID")))
-        }
+    async fn get(&self, ipfs_path: &IpfsPath) -> Result<(Cid, Ipld), Error> {
+        let resolver = Resolver {
+            client: self.clone(),
+        };
+        let node = resolver.resolve(ipfs_path).await?;
+        Ok((node.cid, node.data))
     }
     async fn put(&self, cid: Cid, blob: Bytes, links: Vec<Cid>) -> Result<(), Error> {
+        // Advertise we provide the content
+        self.client()
+            .try_p2p()
+            .map_err(Error::Internal)?
+            .start_providing(&cid)
+            .await
+            .map_err(Error::Internal)?;
         Ok(self
             .client()
             .try_store()
@@ -106,8 +152,12 @@ impl IpfsDep for Api {
             .await
             .map_err(Error::Internal)?)
     }
-    async fn resolve(&self, ipfs_path: &IpfsPath) -> Result<Vec<Cid>, Error> {
-        Ok(self.resolve(ipfs_path).await.map_err(Error::Internal)?)
+    async fn resolve(&self, ipfs_path: &IpfsPath) -> Result<(Cid, String), Error> {
+        let resolver = Resolver {
+            client: self.clone(),
+        };
+        let node = resolver.resolve(ipfs_path).await?;
+        Ok((node.cid, node.path.to_string_lossy().to_string()))
     }
     async fn peers(&self) -> Result<HashMap<PeerId, Vec<Multiaddr>>, Error> {
         Ok(self
@@ -158,5 +208,89 @@ impl IpfsDep for Api {
             .iter()
             .map(|t| t.to_string())
             .collect())
+    }
+}
+
+// Resolves IPFS paths to their DAG node
+// Suppots the following codecs:
+// * dag-cbor
+// * dag-json
+// * dag-jose
+struct Resolver {
+    client: Api,
+}
+
+// Represents an IPFS DAG node
+struct Node {
+    // CID of the block that contains the node.
+    cid: Cid,
+    // Relative path of the node within block.
+    path: PathBuf,
+    // The node data itself.
+    data: Ipld,
+}
+
+impl Resolver {
+    async fn resolve(&self, path: &IpfsPath) -> Result<Node, Error> {
+        let root_cid = *path
+            .cid()
+            .ok_or_else(|| Error::Invalid(anyhow!("path must start with a CID")))?;
+        let root = self.load_cid(root_cid).await?;
+
+        let mut current = root;
+
+        let parts = path.tail();
+        for part in parts.iter().filter(|s| !s.is_empty()) {
+            // Parse part as an integer and if that fails parse as a string into an index.
+            let index: libipld::ipld::IpldIndex = if let Ok(i) = part.parse::<usize>() {
+                i.into()
+            } else {
+                part.clone().into()
+            };
+            current.path = current.path.join(part.to_owned());
+            current.data = current.data.take(index).map_err(|_| {
+                Error::Invalid(anyhow!(
+                    "IPLD resolve error: Couldn't find part {} in path '{}'",
+                    part,
+                    parts.join("/")
+                ))
+            })?;
+
+            // Check if we have found a link and follow it
+            if let Ipld::Link(c) = current.data {
+                current = self.load_cid(c).await?;
+            }
+            // Treat payload/bytes that is a valid CID as a link
+            // This is DAG-JOSE specific logic
+            if current.path.ends_with("payload") {
+                if let Ipld::Bytes(bytes) = &current.data {
+                    if let Ok(c) = Cid::try_from(bytes.as_slice()) {
+                        current = self.load_cid(c).await?;
+                    }
+                }
+            }
+        }
+        Ok(current)
+    }
+    async fn load_cid(&self, cid: Cid) -> Result<Node, Error> {
+        let bytes = self.client.get_raw(cid).await.map_err(Error::Internal)?;
+        let data = match cid.codec() {
+            //TODO(nathanielc): create constants for these
+            // dag-cbor
+            0x71 => {
+                Ipld::decode(DagCborCodec, &mut Cursor::new(&bytes)).map_err(Error::Internal)?
+            }
+            // dag-json
+            0x0129 => {
+                Ipld::decode(DagJsonCodec, &mut Cursor::new(&bytes)).map_err(Error::Internal)?
+            }
+            // dag-jose
+            0x85 => {
+                Ipld::decode(DagJoseCodec, &mut Cursor::new(&bytes)).map_err(Error::Internal)?
+            }
+            _ => return Err(Error::Invalid(anyhow!("unsupported codec {}", cid.codec()))),
+        };
+        let path = PathBuf::new();
+        Ok(Node { cid, path, data })
     }
 }

--- a/ceramic-kubo-rpc/src/lib.rs
+++ b/ceramic-kubo-rpc/src/lib.rs
@@ -247,7 +247,7 @@ impl Resolver {
             } else {
                 part.clone().into()
             };
-            current.path = current.path.join(part.to_owned());
+            current.path = current.path.join(part);
             current.data = current.data.take(index).map_err(|_| {
                 Error::Invalid(anyhow!(
                     "IPLD resolve error: Couldn't find part {} in path '{}'",

--- a/ceramic-kubo-rpc/src/pin.rs
+++ b/ceramic-kubo-rpc/src/pin.rs
@@ -14,7 +14,7 @@ where
     // Therefore we do not need to track which blocks are pinned.
 
     // Get the data, this will ensure its stored locally.
-    let (cid, _bytes) = client.get(ipfs_path).await?;
+    let (cid, _data) = client.get(ipfs_path).await?;
     Ok(cid)
 }
 

--- a/ceramic-one/Cargo.toml
+++ b/ceramic-one/Cargo.toml
@@ -25,3 +25,4 @@ clap = { version = "4", features = ["derive"] }
 names = "0.14"
 opentelemetry.workspace = true
 opentelemetry-otlp.workspace = true
+tempdir = "0.3.7"

--- a/ceramic-one/src/main.rs
+++ b/ceramic-one/src/main.rs
@@ -26,6 +26,8 @@ enum Command {
 struct DaemonOpts {
     #[arg(short, long, default_value = "127.0.0.1:5001")]
     bind_address: String,
+    #[arg(short, long)]
+    store_dir: Option<PathBuf>,
     #[arg(short, long, default_value_t = false)]
     metrics: bool,
     #[arg(short, long, default_value_t = false)]
@@ -52,9 +54,12 @@ async fn daemon(opts: DaemonOpts) -> Result<()> {
         .expect("failed to initialize metrics");
     info!(service_name, instance_id);
 
-    let dir = match home::home_dir() {
-        Some(home_dir) => home_dir.join(".ceramic-one"),
-        None => PathBuf::from(".ceramic-one"),
+    let dir = match opts.store_dir {
+        Some(dir) => dir,
+        None => match home::home_dir() {
+            Some(home_dir) => home_dir.join(".ceramic-one"),
+            None => PathBuf::from(".ceramic-one"),
+        },
     };
     debug!("Using directory: {}", dir.display());
 

--- a/ceramic-one/src/main.rs
+++ b/ceramic-one/src/main.rs
@@ -66,12 +66,9 @@ async fn daemon(opts: DaemonOpts) -> Result<()> {
     let store = RocksStoreService::new(dir.join("store")).await?;
 
     let mut p2p_config = Libp2pConfig::default();
-    p2p_config.bootstrap_peers = vec![
-        "/dns4/go-ipfs-ceramic-private-mainnet-external.3boxlabs.com/tcp/4011/ws/p2p/QmXALVsXZwPWTUbsT8G6VVzzgTJaAWRUD7FWL5f7d5ubAL".parse().unwrap(),
-        "/dns4/go-ipfs-ceramic-private-cas-mainnet-external.3boxlabs.com/tcp/4011/ws/p2p/QmUvEKXuorR7YksrVgA7yKGbfjWHuCRisw2cH9iqRVM9P8".parse().unwrap(),
-        "/dns4/go-ipfs-ceramic-elp-1-1-external.3boxlabs.com/tcp/4011/ws/p2p/QmUiF8Au7wjhAF9BYYMNQRW5KhY7o8fq4RUozzkWvHXQrZ".parse().unwrap(),
-        "/dns4/go-ipfs-ceramic-elp-1-2-external.3boxlabs.com/tcp/4011/ws/p2p/QmRNw9ZimjSwujzS3euqSYxDW9EHDU5LB3NbLQ5vJ13hwJ".parse().unwrap(),
-    ];
+    // Do not use any bootstrap_peers,
+    // js-ceramic will initialize the bootstrap_peers when it connects.
+    p2p_config.bootstrap_peers = vec![];
     p2p_config.listening_multiaddrs = vec![
         "/ip4/0.0.0.0/tcp/0".parse().unwrap(),
         "/ip4/0.0.0.0/udp/0/quic-v1".parse().unwrap(),


### PR DESCRIPTION
Prior to this change dag/get and dag/resolve requests could not follow links into DAG-JOSE encoded nodes. This is now supported by implementing a simple resolver.

Additionally the `id` endpoint has been added and various bugs fixes have been made.