### PR TITLE
chore: add dockerfile for running ceramic-one

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/target
+*/target
+.github
+Dockerfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,15 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build and Publish
+      run: make publish-docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/r5b3e0r5/3box/rust-builder:latest as builder
+
+RUN mkdir -p /home/builder/rust-ceramic
+WORKDIR /home/builder/rust-ceramic
+ADD . .
+RUN make release
+CMD ["/home/builder/rust-ceramic/target/release/ceramic-one"]
+
+FROM ubuntu:latest
+
+COPY --from=builder /home/builder/rust-ceramic/target/release/ceramic-one /usr/bin
+
+CMD ["/usr/bin/ceramic-one"]

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ build:
 	# Build with all features
 	cargo build --locked --all-features
 
+.PHONY: release
+release:
+	cargo build -p ceramic-one --locked --release
+
 .PHONY: test
 test:
 	# Test with default features
@@ -35,3 +39,8 @@ check-clippy:
 .PHONY: run
 run:
 	RUST_LOG=ERROR,ceramic_kubo_rpc=DEBUG,ceramic_one=DEBUG cargo run --all-features --locked --bin ceramic-one -- daemon -b 127.0.0.1:5001
+
+.PHONY: publish-docker
+publish-docker:
+	./ci-scripts/publish.sh
+

--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Build and publish a docker image run running ceramic-one
+#
+# DOCKER_PASSWORD must be set
+# Use:
+#
+#   export DOCKER_PASSWORD=$(aws ecr-public get-login-password --region us-east-1)
+#
+# to get a docker login password.
+
+echo "${DOCKER_PASSWORD}" | docker login --username AWS --password-stdin public.ecr.aws/r5b3e0r5
+docker buildx build -t 3box/ceramic-one .
+docker tag 3box/ceramic-one:latest public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest
+docker push public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest


### PR DESCRIPTION
This change adds a Dockerfile that builds an image to run the ceramic-one binary.

Additionally CI workflows are added to publish a new version of the image on pushes to main.