### PR TITLE
feat: adds eye command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -211,7 +211,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -397,50 +397,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-wincon",
- "concolor-override",
- "concolor-query",
- "is-terminal",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
-dependencies = [
- "anstyle",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 dependencies = [
  "backtrace",
 ]
@@ -503,7 +463,7 @@ checksum = "db8b7511298d5b7784b40b092d9e9dcd3a627a5707e4b5e507931ab0d44eeebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "synstructure",
 ]
 
@@ -515,7 +475,7 @@ checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "synstructure",
 ]
 
@@ -527,7 +487,7 @@ checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -609,14 +569,14 @@ checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -625,24 +585,24 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn",
 ]
 
 [[package]]
@@ -817,7 +777,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -956,7 +916,7 @@ checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1074,6 +1034,7 @@ dependencies = [
  "iroh-rpc-client",
  "libipld",
  "libp2p",
+ "libp2p-tls",
  "mime",
  "multiaddr",
  "serde",
@@ -1091,17 +1052,24 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ceramic-kubo-rpc",
- "clap 4.2.1",
+ "clap 4.1.8",
+ "expect-test",
  "futures-util",
  "git-version",
  "home",
  "iroh-api",
  "iroh-embed",
  "iroh-metrics",
+ "libipld",
+ "libp2p",
+ "multiaddr",
  "names",
  "opentelemetry",
  "opentelemetry-otlp",
- "tempdir",
+ "prometheus-client",
+ "serde",
+ "serde_json",
+ "serde_repr",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -1247,26 +1215,17 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.1"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
- "clap_builder",
- "clap_derive 4.2.0",
- "once_cell",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
-dependencies = [
- "anstream",
- "anstyle",
  "bitflags",
- "clap_lex 0.4.1",
+ "clap_derive 4.1.8",
+ "clap_lex 0.3.2",
+ "is-terminal",
+ "once_cell",
  "strsim",
+ "termcolor",
 ]
 
 [[package]]
@@ -1279,19 +1238,20 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn",
 ]
 
 [[package]]
@@ -1305,9 +1265,12 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -1333,21 +1296,6 @@ dependencies = [
  "mime_guess",
  "rand 0.8.5",
  "thiserror",
-]
-
-[[package]]
-name = "concolor-override"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
-
-[[package]]
-name = "concolor-query"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
-dependencies = [
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1564,7 +1512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1646,7 +1594,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1663,7 +1611,7 @@ checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1702,7 +1650,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1713,7 +1661,7 @@ checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1752,7 +1700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1812,7 +1760,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1833,7 +1781,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1843,7 +1791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
  "derive_builder_core",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1856,7 +1804,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1915,7 +1863,7 @@ checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2017,7 +1965,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2134,12 +2082,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2211,7 +2153,7 @@ checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2340,7 +2282,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2908,7 +2850,7 @@ dependencies = [
  "axum",
  "bytes",
  "cid 0.9.0",
- "clap 4.2.1",
+ "clap 4.1.8",
  "config",
  "futures",
  "git-version",
@@ -2989,7 +2931,7 @@ dependencies = [
  "axum",
  "bytes",
  "cid 0.9.0",
- "clap 4.2.1",
+ "clap 4.1.8",
  "config",
  "futures",
  "headers",
@@ -3022,7 +2964,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "cid 0.9.0",
- "clap 4.2.1",
+ "clap 4.1.8",
  "config",
  "futures",
  "futures-util",
@@ -3128,7 +3070,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "cid 0.9.0",
- "clap 4.2.1",
+ "clap 4.1.8",
  "config",
  "ctrlc",
  "futures",
@@ -3346,7 +3288,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "synstructure",
 ]
 
@@ -3817,7 +3759,7 @@ checksum = "9d527d5827582abd44a6d80c07ff8b50b4ee238a8979e05998474179e79dc400"
 dependencies = [
  "heck",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -4082,9 +4024,9 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.17"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mime_classifier"
@@ -4206,7 +4148,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "synstructure",
 ]
 
@@ -4461,7 +4403,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -4772,7 +4714,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -4826,7 +4768,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -4855,7 +4797,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -4986,7 +4928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebcd279d20a4a0a2404a33056388e950504d891c855c7975b9a8fef75f3bf04"
 dependencies = [
  "proc-macro2",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -5008,7 +4950,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "version_check",
 ]
 
@@ -5031,9 +4973,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -5058,7 +5000,7 @@ checksum = "66a455fbcb954c1a7decf3c586e860fd7889cddf4b8e164be736dbac95a953cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -5088,7 +5030,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 1.0.109",
+ "syn",
  "tempfile",
  "which",
 ]
@@ -5116,7 +5058,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -5145,7 +5087,7 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -5202,24 +5144,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
 ]
 
 [[package]]
@@ -5265,21 +5194,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -5356,15 +5270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5415,15 +5320,6 @@ name = "relative-path"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "rend"
@@ -5531,7 +5427,7 @@ checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -5811,9 +5707,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
 dependencies = [
  "serde_derive",
 ]
@@ -5847,13 +5743,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn",
 ]
 
 [[package]]
@@ -5870,9 +5766,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -5897,6 +5793,17 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395627de918015623b32e7669714206363a7fc00382bf477e72c1f7533e8eafc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5936,7 +5843,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -6213,17 +6120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6237,7 +6133,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "unicode-xid",
 ]
 
@@ -6292,16 +6188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6325,9 +6211,9 @@ dependencies = [
 
 [[package]]
 name = "testdir"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31eb500f7513b559ed7e0652894268dbe8ef27b6241b783ce274f4741eae137"
+checksum = "a45fc921e7c4ad1aedb3484811514f3e5cd187886e0bbf1302c175f7578ef552"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -6345,22 +6231,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn",
 ]
 
 [[package]]
@@ -6427,13 +6313,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
+ "memchr",
  "mio",
  "num_cpus",
  "parking_lot 0.12.1",
@@ -6465,13 +6352,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn",
 ]
 
 [[package]]
@@ -6562,7 +6449,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -6635,9 +6522,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-actix-web"
-version = "0.7.3"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a230d51c76e70c5ff8edae9085d7d7161803a871880406a6772639def50d059c"
+checksum = "4082e4d81173e0b7ad3cfb71e9eaef0dd0cbb7b139fdb56394f488a3b0760b23"
 dependencies = [
  "actix-web",
  "pin-project",
@@ -6653,7 +6540,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -6871,9 +6758,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unimock"
-version = "0.4.12"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa46b37ccb0341a256f583def2628c2d00158c37dac5f4ede95f4fa0dcf01ce6"
+checksum = "9d287bcbde515749baa159c8aff96aefb16808ba43669f1639ae3228e5350f9f"
 dependencies = [
  "once_cell",
  "pretty_assertions",
@@ -6882,13 +6769,13 @@ dependencies = [
 
 [[package]]
 name = "unimock_macros"
-version = "0.4.12"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c574c9b375e8e4d35027aee2959c7b4b384ca9d94e3d9a7fa50640b8b0d4ff16"
+checksum = "64677cf333b99077788547ec64d5f6aebb323e4d7ce76efb7f19bf6a7fb36165"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn",
 ]
 
 [[package]]
@@ -6946,12 +6833,6 @@ name = "urlencoding"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -7044,7 +6925,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -7078,7 +6959,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7660,7 +7541,7 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "synstructure",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ iroh-api = { git = "https://github.com/nathanielc/beetle", branch = "expose-api-
 iroh-embed = { git = "https://github.com/nathanielc/beetle", branch = "expose-api-client" }
 iroh-metrics = { git = "https://github.com/nathanielc/beetle", branch = "expose-api-client" }
 iroh-rpc-client = { git = "https://github.com/nathanielc/beetle", branch = "expose-api-client" }
+iroh-car = { git = "https://github.com/nathanielc/beetle", branch = "expose-api-client" }
 libipld = "0.15"                                                                                 # use same version as Iroh
 libp2p = { version = "0.50", default-features = false }                                          # use same version as Iroh
 multiaddr = "0.16"                                                                               # use same version as Iroh
@@ -22,6 +23,7 @@ tracing = "0.1"
 tracing-opentelemetry = "0.18"
 tracing-subscriber = "0.3"
 unimock = "0.4"
+libp2p-tls = { version = "=0.1.0-alpha", default-features = false }                              # use explicit version of dep to avoid conflict
 
 # Uncomment these lines to use a local copy of beetle
 #[patch."https://github.com/nathanielc/beetle"]
@@ -29,6 +31,10 @@ unimock = "0.4"
 #iroh-embed = { path = "../beetle/iroh-embed" }
 #iroh-metrics = { path = "../beetle/iroh-metrics" }
 #iroh-rpc-client = { path = "../beetle/iroh-rpc-client" }
+#iroh-car = { path = "../beetle/iroh-car" }
+
+#[patch.crates-io]
+#libp2p = { path = "../rust-libp2p/libp2p" }
 
 [workspace.package]
 version = "0.1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,9 @@ RUN mkdir -p /home/builder/rust-ceramic
 WORKDIR /home/builder/rust-ceramic
 ADD . .
 RUN make release
-CMD ["/home/builder/rust-ceramic/target/release/ceramic-one"]
 
 FROM ubuntu:latest
 
 COPY --from=builder /home/builder/rust-ceramic/target/release/ceramic-one /usr/bin
 
-CMD ["/usr/bin/ceramic-one"]
+ENTRYPOINT ["/usr/bin/ceramic-one", "daemon"]

--- a/kubo-rpc/Cargo.toml
+++ b/kubo-rpc/Cargo.toml
@@ -35,6 +35,7 @@ iroh-rpc-client.workspace = true
 libipld.workspace = true
 libp2p.workspace = true
 mime = { version = "0.3.16", optional = true }
+libp2p-tls.workspace = true
 multiaddr.workspace = true
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }

--- a/kubo-rpc/src/swarm.rs
+++ b/kubo-rpc/src/swarm.rs
@@ -26,6 +26,5 @@ where
     T: IpfsDep,
 {
     client.connect(peer_id, addrs).await?;
-
     Ok(())
 }

--- a/one/Cargo.toml
+++ b/one/Cargo.toml
@@ -11,18 +11,27 @@ repository.workspace = true
 [dependencies]
 anyhow.workspace = true
 ceramic-kubo-rpc = { path = "../kubo-rpc", features = ["http"] }
+clap = { version = "4", features = ["derive", "env"] }
 futures-util.workspace = true
+git-version = "0.3"
 home = "0.5"
 iroh-api.workspace = true
 iroh-embed.workspace = true
 iroh-metrics.workspace = true
+libipld.workspace = true
+libp2p.workspace = true
+multiaddr.workspace = true
+names = "0.14"
+opentelemetry-otlp.workspace = true
+opentelemetry.workspace = true
+prometheus-client = "0.18"
+serde = "1"
+serde_json = "1"
+serde_repr = "0.1"
 tokio.workspace = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
-git-version = "0.3"
-clap = { version = "4", features = ["derive"] }
-names = "0.14"
-opentelemetry.workspace = true
-opentelemetry-otlp.workspace = true
-tempdir = "0.3.7"
+
+[dev-dependencies]
+expect-test = "1"

--- a/one/src/main.rs
+++ b/one/src/main.rs
@@ -2,13 +2,25 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 
-use std::path::PathBuf;
+use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 use anyhow::Result;
+use ceramic_kubo_rpc::dag;
 use clap::{Args, Parser, Subcommand};
-use iroh_embed::{IrohBuilder, Libp2pConfig, P2pService, RocksStoreService};
-use iroh_metrics::config::Config as MetricsConfig;
-use tracing::{debug, info};
+use futures_util::{future, StreamExt};
+use iroh_api::IpfsPath;
+use iroh_api::Multiaddr;
+use iroh_embed::{Iroh, IrohBuilder, Libp2pConfig, P2pService, RocksStoreService};
+use iroh_metrics::{config::Config as MetricsConfig, MetricsHandle};
+use libipld::json::DagJsonCodec;
+use libp2p::metrics::Recorder;
+use tokio::task;
+use tracing::{debug, info, warn};
+
+use crate::{metrics::Metrics, pubsub::Message};
+
+mod metrics;
+mod pubsub;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -19,72 +31,231 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Command {
+    /// Run a daemon process
     Daemon(DaemonOpts),
+    /// Run a process that locally pins all stream tips
+    Eye(EyeOpts),
 }
 
 #[derive(Args, Debug)]
 struct DaemonOpts {
-    #[arg(short, long, default_value = "127.0.0.1:5001")]
+    /// Bind address of the RPC enpoint.
+    #[arg(
+        short,
+        long,
+        default_value = "127.0.0.1:5001",
+        env = "CERAMIC_ONE_BIND_ADDRESS"
+    )]
     bind_address: String,
-    #[arg(short, long)]
+    /// Listen address of the p2p swarm.
+    #[arg(
+        long,
+        default_values_t = vec!["/ip4/0.0.0.0/tcp/0".to_string(), "/ip4/0.0.0.0/udp/0/quic-v1".to_string()],
+        env = "CERAMIC_ONE_SWARM_ADDRESSES"
+    )]
+    swarm_addresses: Vec<String>,
+    /// Address of bootstrap peers.
+    /// There are no default address, use this arg or the API to connect to bootstrap peers as needed.
+    #[arg(long, env = "CERAMIC_ONE_BOOTSTRAP_ADDRESSES")]
+    bootstrap_addresses: Vec<String>,
+    /// Path to storage directory
+    #[arg(short, long, env = "CERAMIC_ONE_STORE_DIR")]
     store_dir: Option<PathBuf>,
-    #[arg(short, long, default_value_t = false)]
+    /// When true metrics will be exported
+    #[arg(long, default_value_t = false, env = "CERAMIC_ONE_METRICS")]
     metrics: bool,
-    #[arg(short, long, default_value_t = false)]
+    /// When true traces will be exported
+    #[arg(long, default_value_t = false, env = "CERAMIC_ONE_TRACING")]
     tracing: bool,
+}
+
+#[derive(Args, Debug)]
+struct EyeOpts {
+    #[command(flatten)]
+    daemon: DaemonOpts,
+
+    /// Topic to listen for tip updates
+    #[arg(
+        short,
+        long,
+        default_value = "/ceramic/testnet-clay",
+        env = "CERAMIC_ONE_TOPIC"
+    )]
+    topic: String,
 }
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     let args = Cli::parse();
     match args.command {
-        Command::Daemon(opts) => daemon(opts).await,
+        Command::Daemon(opts) => {
+            let daemon = Daemon::build(opts).await?;
+            daemon.run().await?;
+            daemon.shutdown().await
+        }
+        Command::Eye(opts) => eye(opts).await,
     }
 }
 
-async fn daemon(opts: DaemonOpts) -> Result<()> {
-    let mut metrics_config = MetricsConfig::default();
-    metrics_config = metrics_config_with_compile_time_info(metrics_config);
-    metrics_config.collect = opts.metrics;
-    metrics_config.tracing = opts.tracing;
-    let service_name = metrics_config.service_name.clone();
-    let instance_id = metrics_config.instance_id.clone();
-    let metrics_handle = iroh_metrics::MetricsHandle::new(metrics_config)
-        .await
-        .expect("failed to initialize metrics");
-    info!(service_name, instance_id);
+struct Daemon {
+    bind_address: String,
+    iroh: Iroh,
+    metrics_handle: MetricsHandle,
+    metrics: Arc<Metrics>,
+}
 
-    let dir = match opts.store_dir {
-        Some(dir) => dir,
-        None => match home::home_dir() {
-            Some(home_dir) => home_dir.join(".ceramic-one"),
-            None => PathBuf::from(".ceramic-one"),
-        },
-    };
-    debug!("Using directory: {}", dir.display());
+impl Daemon {
+    async fn build(opts: DaemonOpts) -> Result<Self> {
+        let mut metrics_config = MetricsConfig::default();
+        metrics_config = metrics_config_with_compile_time_info(metrics_config);
+        metrics_config.collect = opts.metrics;
+        metrics_config.tracing = opts.tracing;
+        let service_name = metrics_config.service_name.clone();
+        let instance_id = metrics_config.instance_id.clone();
+        let metrics = iroh_metrics::MetricsHandle::register(crate::metrics::Metrics::new);
+        let metrics = Arc::new(metrics);
 
-    let store = RocksStoreService::new(dir.join("store")).await?;
+        let metrics_handle = iroh_metrics::MetricsHandle::new(metrics_config.clone())
+            .await
+            .expect("failed to initialize metrics");
+        info!(service_name, instance_id);
 
-    let mut p2p_config = Libp2pConfig::default();
-    // Do not use any bootstrap_peers,
-    // js-ceramic will initialize the bootstrap_peers when it connects.
-    p2p_config.bootstrap_peers = vec![];
-    p2p_config.listening_multiaddrs = vec![
-        "/ip4/0.0.0.0/tcp/0".parse().unwrap(),
-        "/ip4/0.0.0.0/udp/0/quic-v1".parse().unwrap(),
-    ];
-    let p2p = P2pService::new(p2p_config, dir, store.addr()).await?;
+        let dir = match opts.store_dir {
+            Some(dir) => dir,
+            None => match home::home_dir() {
+                Some(home_dir) => home_dir.join(".ceramic-one"),
+                None => PathBuf::from(".ceramic-one"),
+            },
+        };
+        debug!("Using directory: {}", dir.display());
 
-    // Note by default this is configured with an indexer, but not with http resolvers.
-    let iroh = IrohBuilder::new().store(store).p2p(p2p).build().await?;
+        let store = RocksStoreService::new(dir.join("store")).await?;
+        let mut p2p_config = Libp2pConfig::default();
+        p2p_config.mdns = false;
 
-    // Run the HTTP server
-    ceramic_kubo_rpc::http::serve(iroh.api().clone(), opts.bind_address).await?;
+        p2p_config.bitswap_server = true;
+        p2p_config.bitswap_client = true;
+        p2p_config.kademlia = true;
+        p2p_config.autonat = true;
+        p2p_config.relay_server = true;
+        p2p_config.relay_client = true;
+        p2p_config.gossipsub = true;
+        p2p_config.max_conns_out = 2000;
+        p2p_config.max_conns_in = 2000;
+        p2p_config.bootstrap_peers = opts
+            .bootstrap_addresses
+            .iter()
+            .map(|addr| addr.parse())
+            .collect::<Result<Vec<Multiaddr>, multiaddr::Error>>()?;
 
-    // Stop the system gracefully.
-    iroh.stop().await?;
+        p2p_config.listening_multiaddrs = opts
+            .swarm_addresses
+            .iter()
+            .map(|addr| addr.parse())
+            .collect::<Result<Vec<Multiaddr>, multiaddr::Error>>()?;
+        let p2p = P2pService::new(p2p_config, dir, store.addr()).await?;
 
-    metrics_handle.shutdown();
+        // Note by default this is configured with an indexer, but not with http resolvers.
+        let iroh = IrohBuilder::new().store(store).p2p(p2p).build().await?;
+
+        Ok(Daemon {
+            bind_address: opts.bind_address,
+            iroh,
+            metrics_handle,
+            metrics,
+        })
+    }
+    // Start the daemon, await does not return until the daemon is finished.
+    async fn run(&self) -> Result<()> {
+        // Run the HTTP server, this blocks until the HTTP server is shutdown via a unix signal.
+        ceramic_kubo_rpc::http::serve(self.iroh.api().clone(), self.bind_address.clone()).await?;
+        Ok(())
+    }
+    async fn shutdown(self) -> Result<()> {
+        // Stop the system gracefully.
+        self.iroh.stop().await?;
+        self.metrics_handle.shutdown();
+        Ok(())
+    }
+}
+
+async fn eye(opts: EyeOpts) -> Result<()> {
+    let daemon = Daemon::build(opts.daemon).await?;
+
+    // Start subscription
+    let subscription = daemon.iroh.api().p2p()?.subscribe(opts.topic).await?;
+
+    let client = daemon.iroh.api().clone();
+    let metrics = daemon.metrics.clone();
+
+    let p2p_events_handle = task::spawn(subscription.for_each(move |event| {
+        match event.expect("should be a message") {
+            iroh_api::GossipsubEvent::Subscribed { .. } => {}
+            iroh_api::GossipsubEvent::Unsubscribed { .. } => {}
+            iroh_api::GossipsubEvent::Message {
+                from,
+                id: _,
+                message,
+            } => {
+                let msg: Message = serde_json::from_slice(message.data.as_slice())
+                    .expect("should be json message");
+                info!(?msg);
+                match &msg {
+                    Message::Update {
+                        stream: _,
+                        tip,
+                        model: _,
+                    } => {
+                        if let Ok(ipfs_path) = IpfsPath::from_str(tip) {
+                            // Spawn task to get the data for a stream tip when we see one
+                            let client = client.clone();
+                            let metrics = metrics.clone();
+                            task::spawn(async move {
+                                let result = dag::get(client, &ipfs_path, DagJsonCodec).await;
+                                metrics.record(&result);
+                                match result {
+                                    Ok(_) => info!("succeed in loading stream tip: {}", ipfs_path),
+                                    Err(err) => warn!("failed to load stream tip: {}", err),
+                                };
+                            });
+                        } else {
+                            warn!("invalid update tip: {}", tip)
+                        }
+                    }
+                    Message::Response { id: _, tips } => {
+                        for tip in tips.values() {
+                            if let Ok(ipfs_path) = IpfsPath::from_str(tip) {
+                                // Spawn task to get the data for a stream tip when we see one
+                                let client = client.clone();
+                                let metrics = metrics.clone();
+                                task::spawn(async move {
+                                    let result = dag::get(client, &ipfs_path, DagJsonCodec).await;
+                                    metrics.record(&result);
+                                    match result {
+                                        Ok(_) => {
+                                            info!("succeed in loading stream tip: {}", ipfs_path)
+                                        }
+                                        Err(err) => warn!("failed to load stream tip: {}", err),
+                                    };
+                                });
+                            } else {
+                                warn!("invalid update tip: {}", tip)
+                            }
+                        }
+                    }
+                    _ => {}
+                };
+                metrics.record(&(from, msg));
+            }
+        }
+        future::ready(())
+    }));
+
+    daemon.run().await?;
+    daemon.shutdown().await?;
+
+    p2p_events_handle.abort();
+    p2p_events_handle.await.ok();
     Ok(())
 }
 

--- a/one/src/metrics.rs
+++ b/one/src/metrics.rs
@@ -1,0 +1,128 @@
+use iroh_api::PeerId;
+use libp2p::metrics::Recorder;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::registry::Registry;
+use prometheus_client::{encoding::text::Encode, metrics::family::Family};
+
+use crate::pubsub;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
+struct MsgLabels {
+    msg_type: MsgType,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
+enum MsgType {
+    Update,
+    Query,
+    Response,
+    Keepalive,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
+struct PeerLabels {
+    peer_id: String,
+    version: String,
+}
+
+pub struct Metrics {
+    messages: Family<MsgLabels, Counter>,
+    peers: Family<PeerLabels, Counter>,
+    tip_loads: Family<TipLoadLabels, Counter>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
+struct TipLoadLabels {
+    result: TipLoadResult,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
+enum TipLoadResult {
+    Success,
+    Failure,
+}
+
+impl Metrics {
+    pub fn new(registry: &mut Registry) -> Self {
+        let sub_registry = registry.sub_registry_with_prefix("ceramic");
+
+        let messages = Family::<MsgLabels, Counter>::default();
+
+        // Create each combination of labels so that we have explicit zeros reported
+        // until the first message arrives.
+        messages
+            .get_or_create(&MsgLabels {
+                msg_type: MsgType::Update,
+            })
+            .get();
+        messages
+            .get_or_create(&MsgLabels {
+                msg_type: MsgType::Query,
+            })
+            .get();
+        messages
+            .get_or_create(&MsgLabels {
+                msg_type: MsgType::Response,
+            })
+            .get();
+        messages
+            .get_or_create(&MsgLabels {
+                msg_type: MsgType::Keepalive,
+            })
+            .get();
+
+        sub_registry.register(
+            "pubsub_messages",
+            "Number of ceramic pubsub messages received",
+            Box::new(messages.clone()),
+        );
+
+        let peers = Family::<PeerLabels, Counter>::default();
+        sub_registry.register(
+            "peers",
+            "Number of keepalive messages from each peer, useful for understanding network topology",
+            Box::new(peers.clone()),
+        );
+
+        let tip_loads = Family::<TipLoadLabels, Counter>::default();
+        sub_registry.register("tip_loads", "Number tip loads", Box::new(tip_loads.clone()));
+
+        Self {
+            messages,
+            peers,
+            tip_loads,
+        }
+    }
+}
+
+impl Recorder<(PeerId, pubsub::Message)> for Metrics {
+    fn record(&self, event: &(PeerId, pubsub::Message)) {
+        let msg_type = match &event.1 {
+            pubsub::Message::Update { .. } => MsgType::Update,
+            pubsub::Message::Query { .. } => MsgType::Query,
+            pubsub::Message::Response { .. } => MsgType::Response,
+            pubsub::Message::Keepalive { ver, .. } => {
+                self.peers
+                    .get_or_create(&PeerLabels {
+                        peer_id: event.0.to_string(),
+                        version: ver.to_owned(),
+                    })
+                    .inc();
+                MsgType::Keepalive
+            }
+        };
+        self.messages.get_or_create(&MsgLabels { msg_type }).inc();
+    }
+}
+
+impl<E> Recorder<Result<Vec<u8>, E>> for Metrics {
+    fn record(&self, event: &Result<Vec<u8>, E>) {
+        let result = match event {
+            Ok(_) => TipLoadResult::Success,
+            Err(_) => TipLoadResult::Failure,
+        };
+        self.tip_loads
+            .get_or_create(&TipLoadLabels { result })
+            .inc();
+    }
+}

--- a/one/src/pubsub.rs
+++ b/one/src/pubsub.rs
@@ -1,0 +1,329 @@
+use std::{collections::HashMap, fmt};
+
+use serde::de;
+use serde::Deserializer;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+#[derive(Debug, Serialize_repr, Deserialize_repr)]
+#[repr(i8)]
+pub enum MessageType {
+    Update = 0,
+    Query = 1,
+    Response = 2,
+    Keepalive = 3,
+}
+
+#[derive(Debug)]
+pub enum Message {
+    Update {
+        stream: String,
+        tip: String,
+        model: Option<String>,
+    },
+    Query {
+        id: String,
+        stream: String,
+    },
+    Response {
+        id: String,
+        tips: HashMap<String, String>,
+    },
+    Keepalive {
+        ts: i64,
+        ver: String,
+    },
+}
+
+// We need manually implement deserialize for Message until this feature is implemented
+// https://github.com/serde-rs/serde/issues/745
+// PR implementing the feature https://github.com/serde-rs/serde/pull/2056
+impl<'de> de::Deserialize<'de> for Message {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct MessageVisitor;
+
+        impl<'de> de::Visitor<'de> for MessageVisitor {
+            type Value = Message;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("message type")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                if let Some(key) = map.next_key::<String>()? {
+                    if key != "typ" {
+                        return Err(de::Error::missing_field("typ"));
+                    }
+                    let typ: MessageType = map.next_value()?;
+                    match typ {
+                        MessageType::Update => {
+                            let mut stream: Option<String> = None;
+                            let mut tip: Option<String> = None;
+                            let mut model: Option<String> = None;
+                            loop {
+                                match map.next_key::<&str>()? {
+                                    Some("stream") => {
+                                        stream = Some(map.next_value()?);
+                                    }
+                                    Some("tip") => {
+                                        tip = Some(map.next_value()?);
+                                    }
+                                    Some("model") => {
+                                        model = Some(map.next_value()?);
+                                    }
+                                    // Explicitly ignore the doc field
+                                    Some("doc") => {
+                                        map.next_value::<&str>()?;
+                                    }
+                                    // Error on unknown fields
+                                    Some(k) => {
+                                        return Err(de::Error::unknown_field(
+                                            k,
+                                            &["stream", "tip", "model", "doc"],
+                                        ));
+                                    }
+                                    None => {
+                                        // We are done, validate we got all fields and return
+                                        if let Some(stream) = stream {
+                                            if let Some(tip) = tip {
+                                                return Ok(Message::Update { stream, tip, model });
+                                            } else {
+                                                return Err(de::Error::missing_field("tip"));
+                                            }
+                                        } else {
+                                            return Err(de::Error::missing_field("stream"));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        MessageType::Query => {
+                            let mut id: Option<String> = None;
+                            let mut stream: Option<String> = None;
+                            loop {
+                                match map.next_key::<&str>()? {
+                                    Some("id") => {
+                                        id = Some(map.next_value()?);
+                                    }
+                                    Some("stream") => {
+                                        stream = Some(map.next_value()?);
+                                    }
+                                    // Explicitly ignore the doc field
+                                    Some("doc") => {
+                                        map.next_value::<&str>()?;
+                                    }
+                                    // Error on unknown fields
+                                    Some(k) => {
+                                        return Err(de::Error::unknown_field(
+                                            k,
+                                            &["id", "stream", "doc"],
+                                        ));
+                                    }
+                                    None => {
+                                        // We are done, validate we got all fields and return
+                                        if let Some(stream) = stream {
+                                            if let Some(id) = id {
+                                                return Ok(Message::Query { stream, id });
+                                            } else {
+                                                return Err(de::Error::missing_field("id"));
+                                            }
+                                        } else {
+                                            return Err(de::Error::missing_field("stream"));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        MessageType::Response => {
+                            let mut id: Option<String> = None;
+                            let mut tips: Option<HashMap<String, String>> = None;
+                            loop {
+                                match map.next_key::<&str>()? {
+                                    Some("id") => {
+                                        id = Some(map.next_value()?);
+                                    }
+                                    Some("tips") => {
+                                        tips = Some(map.next_value()?);
+                                    }
+                                    // Error on unknown fields
+                                    Some(k) => {
+                                        return Err(de::Error::unknown_field(k, &["id", "tips"]));
+                                    }
+                                    None => {
+                                        // We are done, validate we got all fields and return
+                                        if let Some(id) = id {
+                                            if let Some(tips) = tips {
+                                                return Ok(Message::Response { id, tips });
+                                            } else {
+                                                return Err(de::Error::missing_field("tips"));
+                                            }
+                                        } else {
+                                            return Err(de::Error::missing_field("id"));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        MessageType::Keepalive => {
+                            let mut ts: Option<i64> = None;
+                            let mut ver: Option<String> = None;
+                            loop {
+                                match map.next_key::<&str>()? {
+                                    Some("ts") => {
+                                        ts = Some(map.next_value()?);
+                                    }
+                                    Some("ver") => {
+                                        ver = Some(map.next_value()?);
+                                    }
+                                    // Error on unknown fields
+                                    Some(k) => {
+                                        return Err(de::Error::unknown_field(k, &["ts", "ver"]));
+                                    }
+                                    None => {
+                                        // We are done, validate we got all fields and return
+                                        if let Some(ts) = ts {
+                                            if let Some(ver) = ver {
+                                                return Ok(Message::Keepalive { ts, ver });
+                                            } else {
+                                                return Err(de::Error::missing_field("ver"));
+                                            }
+                                        } else {
+                                            return Err(de::Error::missing_field("ts"));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    Err(de::Error::missing_field("typ"))
+                }
+            }
+        }
+
+        deserializer.deserialize_map(MessageVisitor {})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use expect_test::{expect, Expect};
+
+    fn deserialize(json: &str, expect: Expect) {
+        let msg: Message = serde_json::from_str(json).unwrap();
+        expect.assert_debug_eq(&msg);
+    }
+
+    #[test]
+    fn test_de_update() {
+        // Test with minimum required fields
+        deserialize(
+            r#"{
+    "typ":0,
+    "stream": "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39",
+    "tip": "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39"
+}"#,
+            expect![[r#"
+                Update {
+                    stream: "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39",
+                    tip: "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39",
+                    model: None,
+                }
+            "#]],
+        );
+        // Test with maximum fields
+        deserialize(
+            r#"{
+    "typ":0,
+    "stream": "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39",
+    "doc": "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39",
+    "model": "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39",
+    "tip": "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39"
+}"#,
+            expect![[r#"
+                Update {
+                    stream: "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39",
+                    tip: "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39",
+                    model: Some(
+                        "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39",
+                    ),
+                }
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_de_query() {
+        // Test with minimum required fields
+        deserialize(
+            r#"{
+    "typ":1,
+    "id":"EiDJzhPfx5LNWKc2G49O42NvgfXb76bhKwTTdXapSujoGg",
+    "stream": "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39"
+}"#,
+            expect![[r#"
+                Query {
+                    id: "EiDJzhPfx5LNWKc2G49O42NvgfXb76bhKwTTdXapSujoGg",
+                    stream: "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39",
+                }
+            "#]],
+        );
+        // Test with maximum fields
+        deserialize(
+            r#"{
+    "typ":1,
+    "id":"EiDJzhPfx5LNWKc2G49O42NvgfXb76bhKwTTdXapSujoGg",
+    "stream": "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39",
+    "doc":"kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39"
+}"#,
+            expect![[r#"
+                Query {
+                    id: "EiDJzhPfx5LNWKc2G49O42NvgfXb76bhKwTTdXapSujoGg",
+                    stream: "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39",
+                }
+            "#]],
+        );
+    }
+    #[test]
+    fn test_de_response() {
+        // Test with minimum required fields
+        deserialize(
+            r#"{
+    "typ":2,
+    "id":"EiDJzhPfx5LNWKc2G49O42NvgfXb76bhKwTTdXapSujoGg",
+    "tips": {"kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39":
+    "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39"}
+}"#,
+            expect![[r#"
+                Response {
+                    id: "EiDJzhPfx5LNWKc2G49O42NvgfXb76bhKwTTdXapSujoGg",
+                    tips: {
+                        "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39": "kjzl6cwe1jw145as2el62s5k2n5xwij7snqu1mngluhpr05xy5wylfswe1zvq39",
+                    },
+                }
+            "#]],
+        );
+    }
+    #[test]
+    fn test_de_keepalive() {
+        deserialize(
+            r#"{
+    "typ":3,
+    "ts": 5,
+    "ver": "2.23.0"
+}"#,
+            expect![[r#"
+                Keepalive {
+                    ts: 5,
+                    ver: "2.23.0",
+                }
+            "#]],
+        );
+    }
+}


### PR DESCRIPTION
The `eye` command to the `ceramic-one` CLI starts a normal daemon and then subscribes to a gossipsub ceramic topic locally pinning any tips it learns about.

The `eye` behavior along with the existing metrics and traces has proven to be a useful tool to understand how ceramic-one is behaving.