### PR TITLE
feat: add /metrics endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,20 +519,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-compression"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
-dependencies = [
- "brotli",
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite 0.2.9",
- "tokio",
-]
-
-[[package]]
 name = "async-io"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,17 +545,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
  "event-listener",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -663,11 +638,7 @@ dependencies = [
  "pin-project-lite 0.2.9",
  "rustversion",
  "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper",
- "tokio",
  "tower",
  "tower-http",
  "tower-layer",
@@ -723,12 +694,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -961,37 +926,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "cbor4ii"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,13 +965,18 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
+ "bytes",
+ "cid 0.9.0",
  "dag-jose",
  "expect-test",
  "futures-util",
  "hex",
- "iroh-api",
- "iroh-embed",
+ "iroh-metrics",
+ "iroh-p2p",
  "iroh-rpc-client",
+ "iroh-rpc-types",
+ "iroh-store",
+ "itertools",
  "libipld",
  "libp2p",
  "libp2p-tls",
@@ -1046,6 +985,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
  "tracing",
  "tracing-actix-web",
  "tracing-opentelemetry",
@@ -1056,16 +996,21 @@ dependencies = [
 name = "ceramic-one"
 version = "0.1.0"
 dependencies = [
+ "actix-http",
+ "actix-web",
  "anyhow",
  "ceramic-kubo-rpc",
  "clap 4.1.11",
  "expect-test",
+ "futures",
  "futures-util",
  "git-version",
  "home",
- "iroh-api",
- "iroh-embed",
  "iroh-metrics",
+ "iroh-p2p",
+ "iroh-rpc-client",
+ "iroh-rpc-types",
+ "iroh-store",
  "libipld",
  "libp2p",
  "multiaddr",
@@ -2012,12 +1957,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastmurmur3"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d922f481ae01f2a3f1fff7b9e0e789f18f0c755a38ec983a3e6f37762cdcc2a2"
-
-[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,51 +2267,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "handlebars"
-version = "4.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "035ef95d03713f2c347a72547b7cd38cbc9af7cd51e6099fb62d586d4a6dee3a"
-dependencies = [
- "log",
- "pest",
- "pest_derive",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.6",
-]
-
-[[package]]
-name = "headers"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
-dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http",
 ]
 
 [[package]]
@@ -2410,12 +2310,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-literal"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hex_fmt"
@@ -2498,16 +2392,6 @@ name = "http-range-header"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
-
-[[package]]
-name = "http-serde"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e272971f774ba29341db2f686255ff8a979365a26fb9e4277f6b6d9ec0cdd5e"
-dependencies = [
- "http",
- "serde",
-]
 
 [[package]]
 name = "httparse"
@@ -2689,16 +2573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-dependencies = [
- "async-trait",
- "tokio",
-]
-
-[[package]]
 name = "interceptor"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,35 +2620,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
-name = "iroh-api"
-version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
-dependencies = [
- "anyhow",
- "async-stream",
- "async-trait",
- "bytes",
- "cid 0.9.0",
- "config",
- "futures",
- "iroh-metrics",
- "iroh-resolver",
- "iroh-rpc-client",
- "iroh-rpc-types",
- "iroh-unixfs",
- "iroh-util",
- "libp2p",
- "relative-path",
- "serde",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "iroh-bitswap"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#28f1ea735123e62b8ea2430dad66157010fbb763"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -2810,104 +2658,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-car"
-version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
-dependencies = [
- "cid 0.9.0",
- "futures",
- "integer-encoding",
- "libipld",
- "libipld-cbor",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "iroh-embed"
-version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
-dependencies = [
- "anyhow",
- "futures",
- "iroh-api",
- "iroh-gateway",
- "iroh-metrics",
- "iroh-one",
- "iroh-p2p",
- "iroh-resolver",
- "iroh-rpc-client",
- "iroh-rpc-types",
- "iroh-store",
- "iroh-unixfs",
- "reqwest",
- "tokio",
-]
-
-[[package]]
-name = "iroh-gateway"
-version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
-dependencies = [
- "anyhow",
- "async-recursion",
- "async-stream",
- "async-trait",
- "axum",
- "bytes",
- "cid 0.9.0",
- "clap 4.1.11",
- "config",
- "futures",
- "git-version",
- "handlebars",
- "headers",
- "hex",
- "hex-literal",
- "http",
- "http-body",
- "http-serde",
- "hyper",
- "iroh-car",
- "iroh-metrics",
- "iroh-resolver",
- "iroh-rpc-client",
- "iroh-rpc-types",
- "iroh-unixfs",
- "iroh-util",
- "libp2p",
- "mime",
- "mime_classifier",
- "mime_guess",
- "names",
- "once_cell",
- "opentelemetry",
- "phf",
- "rand 0.8.5",
- "reqwest",
- "serde",
- "serde_json",
- "serde_qs",
- "sha2 0.10.6",
- "testdir",
- "time",
- "tokio",
- "tokio-util",
- "toml",
- "tower",
- "tower-http",
- "tower-layer",
- "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber",
- "url",
- "urlencoding",
-]
-
-[[package]]
 name = "iroh-metrics"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#28f1ea735123e62b8ea2430dad66157010fbb763"
 dependencies = [
  "async-trait",
  "config",
@@ -2928,40 +2681,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-one"
-version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
-dependencies = [
- "anyhow",
- "async-trait",
- "axum",
- "bytes",
- "cid 0.9.0",
- "clap 4.1.11",
- "config",
- "futures",
- "headers",
- "http-serde",
- "hyper",
- "iroh-gateway",
- "iroh-metrics",
- "iroh-p2p",
- "iroh-resolver",
- "iroh-rpc-client",
- "iroh-rpc-types",
- "iroh-store",
- "iroh-unixfs",
- "iroh-util",
- "reqwest",
- "serde",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "iroh-p2p"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#28f1ea735123e62b8ea2430dad66157010fbb763"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -2998,35 +2720,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-resolver"
-version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
-dependencies = [
- "anyhow",
- "async-channel",
- "async-stream",
- "async-trait",
- "bs58",
- "bytes",
- "cid 0.9.0",
- "fnv",
- "futures",
- "iroh-metrics",
- "iroh-rpc-client",
- "iroh-unixfs",
- "iroh-util",
- "libipld",
- "libp2p",
- "serde",
- "tokio",
- "tracing",
- "trust-dns-resolver",
-]
-
-[[package]]
 name = "iroh-rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#28f1ea735123e62b8ea2430dad66157010fbb763"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3049,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "iroh-rpc-types"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#28f1ea735123e62b8ea2430dad66157010fbb763"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3067,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "iroh-store"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#28f1ea735123e62b8ea2430dad66157010fbb763"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3099,46 +2795,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-unixfs"
-version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
-dependencies = [
- "anyhow",
- "async-channel",
- "async-recursion",
- "async-stream",
- "async-trait",
- "base64 0.20.0",
- "bytes",
- "cid 0.9.0",
- "config",
- "fastmurmur3",
- "futures",
- "iroh-metrics",
- "iroh-rpc-client",
- "iroh-util",
- "libipld",
- "libp2p",
- "multihash 0.17.0",
- "num_enum",
- "once_cell",
- "prost",
- "prost-build",
- "rand 0.8.5",
- "reqwest",
- "serde",
- "serde_json",
- "tokio",
- "tokio-util",
- "tracing",
- "unsigned-varint",
- "url",
-]
-
-[[package]]
 name = "iroh-util"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#348a7390a99384a1664d14901aa8ea302e83b010"
+source = "git+https://github.com/nathanielc/beetle?branch=expose-api-client#28f1ea735123e62b8ea2430dad66157010fbb763"
 dependencies = [
  "anyhow",
  "cid 0.9.0",
@@ -3149,7 +2808,7 @@ dependencies = [
  "humansize",
  "rlimit",
  "serde",
- "sysinfo 0.27.8",
+ "sysinfo",
  "thiserror",
  "toml",
  "tracing",
@@ -4035,16 +3694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "mime_classifier"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e817cb34c89e147fcfbb8a4e88e4c1c064c1c9fcdab80191f94b55921b3cbbd4"
-dependencies = [
- "mime",
- "serde",
-]
-
-[[package]]
 name = "mime_guess"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4745,48 +4394,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5322,12 +4929,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "relative-path"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
-
-[[package]]
 name = "rend"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5707,9 +5308,6 @@ name = "semver"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde"
@@ -5779,26 +5377,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_path_to_error"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0969fff533976baadd92e08b1d102c5a3d8a8049eadfd69d4d1e3c5b2ed189"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_qs"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cac3f1e2ca2fe333923a1ae72caca910b98ed0630bb35ef6f8c8517d6e81afa"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -5949,12 +5527,6 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
-
-[[package]]
-name = "siphasher"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"
@@ -6145,20 +5717,6 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.26.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c18a6156d1f27a9592ee18c1a846ca8dd5c258b7179fc193ae87c74ebb666f5"
-dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "winapi",
-]
-
-[[package]]
-name = "sysinfo"
 version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a902e9050fca0a5d6877550b769abd2bd1ce8c04634b941dbe2809735e1a1e33"
@@ -6213,20 +5771,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "testdir"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fc921e7c4ad1aedb3484811514f3e5cd187886e0bbf1302c175f7578ef552"
-dependencies = [
- "anyhow",
- "backtrace",
- "cargo_metadata",
- "once_cell",
- "sysinfo 0.26.9",
- "whoami",
 ]
 
 [[package]]
@@ -6484,7 +6028,6 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "async-compression",
  "bitflags 1.3.2",
  "bytes",
  "futures-core",
@@ -6493,12 +6036,9 @@ dependencies = [
  "http-body",
  "http-range-header",
  "pin-project-lite 0.2.9",
- "tokio",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -6619,32 +6159,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
 dependencies = [
  "async-trait",
- "bytes",
  "cfg-if",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
- "h2",
- "http",
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
  "rand 0.8.5",
- "rustls 0.20.8",
- "rustls-pemfile",
- "serde",
  "smallvec",
  "socket2",
  "thiserror",
  "tinyvec",
  "tokio",
- "tokio-rustls",
  "tracing",
  "url",
- "webpki 0.22.0",
- "webpki-roots",
 ]
 
 [[package]]
@@ -6660,15 +6191,11 @@ dependencies = [
  "lru-cache",
  "parking_lot 0.12.1",
  "resolv-conf",
- "rustls 0.20.8",
- "serde",
  "smallvec",
  "thiserror",
  "tokio",
- "tokio-rustls",
  "tracing",
  "trust-dns-proto",
- "webpki-roots",
 ]
 
 [[package]]
@@ -6831,14 +6358,7 @@ dependencies = [
  "form_urlencoded",
  "idna 0.3.0",
  "percent-encoding",
- "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "uuid"
@@ -7251,16 +6771,6 @@ dependencies = [
  "either",
  "libc",
  "once_cell",
-]
-
-[[package]]
-name = "whoami"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45dbc71f0cdca27dc261a9bd37ddec174e4a0af2b900b890f378460f745426e3"
-dependencies = [
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,17 @@ members = ["kubo-rpc", "one"]
 anyhow = "1"
 async-stream = "0.3"
 async-trait = "0.1"
+bytes = "1.1"
 ceramic-one = { path = "./one" }
+cid = "0.9"
 dag-jose = "0.1"
+futures = "0.3"
 futures-util = "0.3"
-iroh-api = { git = "https://github.com/nathanielc/beetle", branch = "expose-api-client" }
-iroh-embed = { git = "https://github.com/nathanielc/beetle", branch = "expose-api-client" }
 iroh-metrics = { git = "https://github.com/nathanielc/beetle", branch = "expose-api-client" }
+iroh-p2p = { git = "https://github.com/nathanielc/beetle", branch = "expose-api-client" }
 iroh-rpc-client = { git = "https://github.com/nathanielc/beetle", branch = "expose-api-client" }
-iroh-car = { git = "https://github.com/nathanielc/beetle", branch = "expose-api-client" }
+iroh-rpc-types = { git = "https://github.com/nathanielc/beetle", branch = "expose-api-client" }
+iroh-store = { git = "https://github.com/nathanielc/beetle", branch = "expose-api-client" }
 libipld = "0.15"                                                                                 # use same version as Iroh
 libp2p = { version = "0.50", default-features = false }                                          # use same version as Iroh
 multiaddr = "0.16"                                                                               # use same version as Iroh
@@ -25,13 +28,14 @@ tracing-subscriber = "0.3"
 unimock = "0.4"
 libp2p-tls = { version = "=0.1.0-alpha", default-features = false }                              # use explicit version of dep to avoid conflict
 
+
 # Uncomment these lines to use a local copy of beetle
 #[patch."https://github.com/nathanielc/beetle"]
-#iroh-api = { path = "../beetle/iroh-api" }
-#iroh-embed = { path = "../beetle/iroh-embed" }
 #iroh-metrics = { path = "../beetle/iroh-metrics" }
+#iroh-p2p = { path = "../beetle/iroh-p2p" }
 #iroh-rpc-client = { path = "../beetle/iroh-rpc-client" }
-#iroh-car = { path = "../beetle/iroh-car" }
+#iroh-rpc-types = { path = "../beetle/iroh-rpc-types" }
+#iroh-store = { path = "../beetle/iroh-store" }
 
 #[patch.crates-io]
 #libp2p = { path = "../rust-libp2p/libp2p" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,23 @@
-FROM public.ecr.aws/r5b3e0r5/3box/rust-builder:latest as builder
+FROM public.ecr.aws/r5b3e0r5/3box/rust-builder:latest as chef
 
 RUN mkdir -p /home/builder/rust-ceramic
 WORKDIR /home/builder/rust-ceramic
-ADD . .
+
+# TODO add to parent builder image
+RUN cargo install cargo-chef
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /home/builder/rust-ceramic/recipe.json recipe.json
+
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Build application
+COPY . .
 RUN make release
 
 FROM ubuntu:latest

--- a/kubo-rpc/Cargo.toml
+++ b/kubo-rpc/Cargo.toml
@@ -24,27 +24,33 @@ actix-http = { version = "3", optional = true }
 actix-multipart = { version = "0.5", optional = true }
 actix-multipart-rfc7578 = { version = "0.10", optional = true }
 actix-web = { version = "4", optional = true }
-async-stream.workspace = true
 anyhow.workspace = true
+async-stream.workspace = true
 async-trait.workspace = true
+bytes.workspace = true
+cid.workspace = true
 dag-jose.workspace = true
 futures-util.workspace = true
-iroh-api.workspace = true
-iroh-embed.workspace = true
+hex = "0.4"
+iroh-metrics.workspace = true
+iroh-p2p.workspace = true
 iroh-rpc-client.workspace = true
+iroh-rpc-types.workspace = true
+iroh-store.workspace = true
+itertools = "0.10.5"
 libipld.workspace = true
+libp2p-tls.workspace = true
 libp2p.workspace = true
 mime = { version = "0.3.16", optional = true }
-libp2p-tls.workspace = true
 multiaddr.workspace = true
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 thiserror = "1"
+tokio.workspace = true
 tracing-actix-web = { version = "0.7", optional = true }
 tracing-opentelemetry.workspace = true
 tracing.workspace = true
 unimock.workspace = true
-hex = "0.4"
 
 [dev-dependencies]
 expect-test = "1"

--- a/kubo-rpc/src/block.rs
+++ b/kubo-rpc/src/block.rs
@@ -1,6 +1,6 @@
 //! Implements the dag endpoints.
 
-use iroh_api::Cid;
+use crate::Cid;
 use libipld::{
     multihash::{Code, MultihashDigest},
     prelude::Codec,

--- a/kubo-rpc/src/dag.rs
+++ b/kubo-rpc/src/dag.rs
@@ -1,7 +1,7 @@
 //! Implements the dag endpoints.
 use std::io::{Read, Seek};
 
-use iroh_api::{Cid, IpfsPath};
+use crate::{Cid, IpfsPath};
 use libipld::{
     multihash::{Code, MultihashDigest},
     prelude::{Codec, Decode, Encode},

--- a/kubo-rpc/src/error.rs
+++ b/kubo-rpc/src/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 /// Error type for specific failures.
 /// These generally come from here
-/// https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+/// <https://grpc.github.io/grpc/core/md_doc_statuscodes.html>
 /// However we start with a minimal set and can add more as needed.
 #[derive(Debug, Error)]
 pub enum Error {

--- a/kubo-rpc/src/http/block.rs
+++ b/kubo-rpc/src/http/block.rs
@@ -5,7 +5,6 @@ use actix_web::{http::header::ContentType, web, HttpResponse, Scope};
 use anyhow::anyhow;
 use dag_jose::DagJoseCodec;
 use futures_util::StreamExt;
-use iroh_api::Cid;
 use libipld::{cbor::DagCborCodec, json::DagJsonCodec};
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +12,7 @@ use crate::{
     block,
     error::Error,
     http::{AppState, DAG_CBOR, DAG_JOSE, DAG_JSON},
-    IpfsDep,
+    Cid, IpfsDep,
 };
 pub fn scope<T>() -> Scope
 where
@@ -195,8 +194,8 @@ mod tests {
 
     use actix_multipart_rfc7578::client::multipart;
     use actix_web::{body, test};
+    use bytes::Bytes;
     use expect_test::expect;
-    use iroh_api::{Bytes, Cid};
     use unimock::MockFn;
     use unimock::{matching, Unimock};
 

--- a/kubo-rpc/src/http/dag.rs
+++ b/kubo-rpc/src/http/dag.rs
@@ -5,7 +5,6 @@ use actix_web::{http::header::ContentType, web, HttpResponse, Scope};
 use anyhow::anyhow;
 use dag_jose::DagJoseCodec;
 use futures_util::StreamExt;
-use iroh_api::IpfsPath;
 use libipld::{cbor::DagCborCodec, ipld, json::DagJsonCodec, prelude::Encode};
 use serde::Deserialize;
 
@@ -13,7 +12,7 @@ use crate::{
     dag,
     error::Error,
     http::{AppState, DAG_CBOR, DAG_JOSE, DAG_JSON},
-    IpfsDep,
+    IpfsDep, IpfsPath,
 };
 pub fn scope<T>() -> Scope
 where
@@ -190,8 +189,8 @@ mod tests {
 
     use actix_multipart_rfc7578::client::multipart;
     use actix_web::{body, test};
+    use cid::Cid;
     use expect_test::expect;
-    use iroh_api::Cid;
     use libipld::{pb::DagPbCodec, prelude::Decode, Ipld};
     use unimock::MockFn;
     use unimock::{matching, Unimock};

--- a/kubo-rpc/src/http/id.rs
+++ b/kubo-rpc/src/http/id.rs
@@ -2,10 +2,10 @@ use std::str::FromStr;
 
 use actix_web::{http::header::ContentType, web, HttpResponse, Scope};
 use anyhow::anyhow;
-use iroh_api::PeerId;
 use serde::{Deserialize, Serialize};
 
-use crate::{error::Error, http::AppState, id, IpfsDep};
+use crate::{error::Error, http::AppState, id, IpfsDep, PeerId};
+
 pub fn scope<T>() -> Scope
 where
     T: IpfsDep + 'static,

--- a/kubo-rpc/src/http/mod.rs
+++ b/kubo-rpc/src/http/mod.rs
@@ -37,7 +37,7 @@ pub const DAG_JOSE: &str = "dag-jose";
 ///
 /// Block until shutdown.
 /// Automatically registers shutdown listeners for interrupt and kill signals.
-/// See https://actix.rs/docs/server/#graceful-shutdown
+/// See <https://actix.rs/docs/server/#graceful-shutdown>
 pub async fn serve<T, A>(api: T, addrs: A) -> std::io::Result<()>
 where
     T: IpfsDep + Send + Clone + 'static,
@@ -137,9 +137,14 @@ mod tests {
         B: MessageBody,
         <B as MessageBody>::Error: std::fmt::Debug,
     {
-        let body_json: serde_json::Value =
-            serde_json::from_slice(body::to_bytes(body).await.unwrap().as_ref())
-                .expect("response body should be valid json");
+        let body_bytes = body::to_bytes(body).await.unwrap();
+        let body_json: serde_json::Value = serde_json::from_slice(body_bytes.as_ref())
+            .unwrap_or_else(|_| {
+                panic!(
+                    "response body should be valid json: {:?}",
+                    String::from_utf8(body_bytes.as_ref().to_vec())
+                )
+            });
         let pretty_json = serde_json::to_string_pretty(&body_json).unwrap();
         expect.assert_eq(&pretty_json);
     }

--- a/kubo-rpc/src/http/pin.rs
+++ b/kubo-rpc/src/http/pin.rs
@@ -2,10 +2,10 @@ use std::str::FromStr;
 
 use actix_web::{http::header::ContentType, web, HttpResponse, Scope};
 use anyhow::anyhow;
-use iroh_api::IpfsPath;
 use serde::{Deserialize, Serialize};
 
-use crate::{error::Error, http::AppState, pin, IpfsDep};
+use crate::{error::Error, http::AppState, pin, IpfsDep, IpfsPath};
+
 pub fn scope<T>() -> Scope
 where
     T: IpfsDep + 'static,
@@ -104,8 +104,8 @@ mod tests {
     use crate::http::tests::{assert_body_json, build_server};
 
     use actix_web::test;
+    use cid::Cid;
     use expect_test::expect;
-    use iroh_api::Cid;
     use libipld::{pb::DagPbCodec, prelude::Decode, Ipld};
     use unimock::MockFn;
     use unimock::{matching, Unimock};

--- a/kubo-rpc/src/http/pubsub.rs
+++ b/kubo-rpc/src/http/pubsub.rs
@@ -161,7 +161,6 @@ mod tests {
     use std::{collections::HashMap, str::FromStr};
 
     use crate::{
-        error::Error,
         http::tests::{assert_body_json, assert_body_json_nl, build_server},
         IpfsDep,
     };
@@ -236,6 +235,9 @@ mod tests {
 
     #[actix_web::test]
     async fn test_subscribe() {
+        use crate::{
+            Bytes, Cid, Error, GossipsubEvent, IpfsPath, Ipld, Multiaddr, PeerId, PeerInfo,
+        };
         // Can't use unimock because it expects the stream to be Sync.
         // So we create a one off implementation of the trait and only implement the method we
         // need.
@@ -246,80 +248,60 @@ mod tests {
         #[async_trait]
         impl IpfsDep for TestDeps {
             /// Get information about the local peer.
-            async fn lookup_local(&self) -> Result<crate::PeerInfo, Error> {
+            async fn lookup_local(&self) -> Result<PeerInfo, Error> {
                 todo!()
             }
             /// Get information about a peer.
-            async fn lookup(&self, _peer_id: crate::PeerId) -> Result<crate::PeerInfo, Error> {
+            async fn lookup(&self, _peer_id: PeerId) -> Result<PeerInfo, Error> {
                 todo!()
             }
             /// Get the size of an IPFS block.
-            async fn block_size(&self, _cid: crate::Cid) -> Result<u64, crate::Error> {
+            async fn block_size(&self, _cid: Cid) -> Result<u64, Error> {
                 todo!()
             }
             /// Get a block from IPFS
-            async fn block_get(&self, _cid: crate::Cid) -> Result<crate::Bytes, crate::Error> {
+            async fn block_get(&self, _cid: Cid) -> Result<Bytes, Error> {
                 todo!()
             }
             /// Get a DAG node from IPFS returning the Cid of the resolved path and the bytes of the node.
             /// This will locally store the data as a result.
-            async fn get(
-                &self,
-                _ipfs_path: &crate::IpfsPath,
-            ) -> Result<(crate::Cid, crate::Ipld), crate::Error> {
+            async fn get(&self, _ipfs_path: &IpfsPath) -> Result<(Cid, Ipld), Error> {
                 todo!()
             }
             /// Store a DAG node into IFPS.
-            async fn put(
-                &self,
-                _cid: crate::Cid,
-                _blob: crate::Bytes,
-                _links: Vec<crate::Cid>,
-            ) -> Result<(), crate::Error> {
+            async fn put(&self, _cid: Cid, _blob: Bytes, _links: Vec<Cid>) -> Result<(), Error> {
                 todo!()
             }
             /// Resolve an IPLD block.
-            async fn resolve(
-                &self,
-                _ipfs_path: &crate::IpfsPath,
-            ) -> Result<(crate::Cid, String), crate::Error> {
+            async fn resolve(&self, _ipfs_path: &IpfsPath) -> Result<(Cid, String), Error> {
                 todo!()
             }
             /// Report all connected peers of the current node.
-            async fn peers(
-                &self,
-            ) -> Result<HashMap<crate::PeerId, Vec<crate::Multiaddr>>, crate::Error> {
+            async fn peers(&self) -> Result<HashMap<PeerId, Vec<Multiaddr>>, Error> {
                 todo!()
             }
             /// Connect to a specific peer node.
-            async fn connect(
-                &self,
-                _peer_id: crate::PeerId,
-                _addrs: Vec<crate::Multiaddr>,
-            ) -> Result<(), Error> {
+            async fn connect(&self, _peer_id: PeerId, _addrs: Vec<Multiaddr>) -> Result<(), Error> {
                 todo!()
             }
             /// Publish a message on a pub/sub Topic.
-            async fn publish(&self, _topic: String, _data: crate::Bytes) -> Result<(), Error> {
+            async fn publish(&self, _topic: String, _data: Bytes) -> Result<(), Error> {
                 todo!()
             }
             async fn subscribe(
                 &self,
                 topic: String,
-            ) -> Result<BoxStream<'static, anyhow::Result<crate::GossipsubEvent>>, Error>
-            {
+            ) -> Result<BoxStream<'static, anyhow::Result<GossipsubEvent>>, Error> {
                 if topic != "topicA" {
                     return Err(Error::Internal(anyhow!("unexpected topic")));
                 }
-                let first = Ok(crate::GossipsubEvent::Message {
-                    from: crate::PeerId::from_str(
-                        "12D3KooWHUfjwiTRVV8jxFcKRSQTPatayC4nQCNX86oxRF5XWzGe",
-                    )
-                    .unwrap(),
+                let first = Ok(GossipsubEvent::Message {
+                    from: PeerId::from_str("12D3KooWHUfjwiTRVV8jxFcKRSQTPatayC4nQCNX86oxRF5XWzGe")
+                        .unwrap(),
                     id: libp2p::gossipsub::MessageId::new(&[]),
                     message: GossipsubMessage {
                         source: Some(
-                            crate::PeerId::from_str(
+                            PeerId::from_str(
                                 "12D3KooWM68GyFKBT9JsuTRB6CYkF61PtMuSkynUauSQEGBX51JW",
                             )
                             .unwrap(),
@@ -329,15 +311,13 @@ mod tests {
                         topic: TopicHash::from_raw("topicA"),
                     },
                 });
-                let second = Ok(crate::GossipsubEvent::Message {
-                    from: crate::PeerId::from_str(
-                        "12D3KooWGnKwtpSh2ZLTvoC8mjiexMNRLNkT92pxq7MDgyJHktNJ",
-                    )
-                    .unwrap(),
+                let second = Ok(GossipsubEvent::Message {
+                    from: PeerId::from_str("12D3KooWGnKwtpSh2ZLTvoC8mjiexMNRLNkT92pxq7MDgyJHktNJ")
+                        .unwrap(),
                     id: libp2p::gossipsub::MessageId::new(&[]),
                     message: GossipsubMessage {
                         source: Some(
-                            crate::PeerId::from_str(
+                            PeerId::from_str(
                                 "12D3KooWQVU9Pv3BqD6bD9w96tJxLedKCj4VZ75oqX9Tav4R4rUS",
                             )
                             .unwrap(),

--- a/kubo-rpc/src/http/swarm.rs
+++ b/kubo-rpc/src/http/swarm.rs
@@ -143,7 +143,10 @@ where
                 "no peer id specificed in multiaddrs"
             )))
         }
-        1 => peer_ids.into_iter().next().unwrap(),
+        1 => peer_ids
+            .into_iter()
+            .next()
+            .expect("unreachable: should be exactly one peer_id"),
         _ => return Err(Error::Invalid(anyhow!("found multiple distinct peer ids"))),
     };
 

--- a/kubo-rpc/src/id.rs
+++ b/kubo-rpc/src/id.rs
@@ -1,7 +1,5 @@
 //! Provides methods for looking up peer info.
-use iroh_api::PeerId;
-
-use crate::{error::Error, IpfsDep, PeerInfo};
+use crate::{error::Error, IpfsDep, PeerId, PeerInfo};
 
 /// Lookup information about a specific peer.
 #[tracing::instrument(skip(client))]

--- a/kubo-rpc/src/lib.rs
+++ b/kubo-rpc/src/lib.rs
@@ -65,6 +65,7 @@ pub struct IpfsPath {
     root: Cid,
     tail: Vec<String>,
 }
+
 impl IpfsPath {
     /// New path from a cid.
     pub fn from_cid(cid: Cid) -> Self {
@@ -84,6 +85,7 @@ impl IpfsPath {
         !self.tail.is_empty() && self.tail.last().unwrap().is_empty()
     }
 }
+
 impl Display for IpfsPath {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "/{}", self.root)?;

--- a/kubo-rpc/src/lib.rs
+++ b/kubo-rpc/src/lib.rs
@@ -1,20 +1,36 @@
 //! Provides an API for performing the Kubo RPC calls consumed by js-ceramic.
 //!
 //! Both a Rust API is provided along with an HTTP server implementation that follows
-//! https://docs.ipfs.tech/reference/kubo/rpc/
+//! <https://docs.ipfs.tech/reference/kubo/rpc/>
 //!
 //! The http server implementation is behind the `http` feature.
 #![deny(warnings)]
 #![deny(missing_docs)]
-use std::{collections::HashMap, io::Cursor, path::PathBuf};
+use std::{
+    collections::HashMap,
+    fmt::{self, Display, Formatter},
+    io::Cursor,
+    path::PathBuf,
+};
+use std::{str::FromStr, sync::Arc};
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use dag_jose::DagJoseCodec;
 use futures_util::stream::BoxStream;
-use iroh_api::{Api, Bytes, Cid, GossipsubEvent, IpfsPath, Multiaddr, PeerId};
-use libipld::{cbor::DagCborCodec, json::DagJsonCodec, prelude::Decode, Ipld};
+use iroh_rpc_client::{P2pClient, StoreClient};
+use libipld::{cbor::DagCborCodec, json::DagJsonCodec, prelude::Decode};
+use libp2p::gossipsub::TopicHash;
+use tracing::{error, trace};
 use unimock::unimock;
+
+// Pub use any types we export as part of an trait or struct
+pub use bytes::Bytes;
+pub use cid::Cid;
+pub use iroh_p2p::PeerId;
+pub use iroh_rpc_types::GossipsubEvent;
+pub use libipld::Ipld;
+pub use libp2p::Multiaddr;
 
 pub mod block;
 pub mod dag;
@@ -41,6 +57,75 @@ pub struct PeerInfo {
     pub listen_addrs: Vec<Multiaddr>,
     /// Protocols supported by the peer.
     pub protocols: Vec<String>,
+}
+
+/// An IPFS path {cid}/path/through/dag
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IpfsPath {
+    root: Cid,
+    tail: Vec<String>,
+}
+impl IpfsPath {
+    /// New path from a cid.
+    pub fn from_cid(cid: Cid) -> Self {
+        Self {
+            root: cid,
+            tail: Vec::new(),
+        }
+    }
+    fn cid(&self) -> Cid {
+        self.root
+    }
+    fn tail(&self) -> &[String] {
+        self.tail.as_slice()
+    }
+    // used only for string path manipulation
+    fn has_trailing_slash(&self) -> bool {
+        !self.tail.is_empty() && self.tail.last().unwrap().is_empty()
+    }
+}
+impl Display for IpfsPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "/{}", self.root)?;
+
+        for part in &self.tail {
+            if part.is_empty() {
+                continue;
+            }
+            write!(f, "/{part}")?;
+        }
+
+        if self.has_trailing_slash() {
+            write!(f, "/")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl FromStr for IpfsPath {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split(&['/', '\\']).filter(|s| !s.is_empty());
+
+        let first_part = parts.next().ok_or_else(|| anyhow!("path too short"))?;
+        let root = if first_part.eq_ignore_ascii_case("ipfs") {
+            parts.next().ok_or_else(|| anyhow!("path too short"))?
+        } else {
+            first_part
+        };
+
+        let root = Cid::from_str(root).context("invalid cid")?;
+
+        let mut tail: Vec<String> = parts.map(Into::into).collect();
+
+        if s.ends_with('/') {
+            tail.push("".to_owned());
+        }
+
+        Ok(IpfsPath { root, tail })
+    }
 }
 
 /// Defines the behavior this crate needs from IPFS in order to serve Kubo RPC calls.
@@ -80,17 +165,33 @@ pub trait IpfsDep: Clone {
     async fn topics(&self) -> Result<Vec<String>, Error>;
 }
 
+/// Implemntation of IPFS APIs
+pub struct IpfsService {
+    p2p: P2pClient,
+    store: StoreClient,
+    resolver: Resolver,
+}
+
+impl IpfsService {
+    /// Create new IpfsService
+    pub fn new(p2p: P2pClient, store: StoreClient) -> Self {
+        let loader = Loader {
+            p2p: p2p.clone(),
+            store: store.clone(),
+        };
+        let resolver = Resolver::new(loader);
+        Self {
+            p2p,
+            store,
+            resolver,
+        }
+    }
+}
 #[async_trait]
-impl IpfsDep for Api {
+impl IpfsDep for Arc<IpfsService> {
     /// Get the ID of the local peer.
     async fn lookup_local(&self) -> Result<PeerInfo, Error> {
-        let l = self
-            .client()
-            .try_p2p()
-            .map_err(Error::Internal)?
-            .lookup_local()
-            .await
-            .map_err(Error::Internal)?;
+        let l = self.p2p.lookup_local().await.map_err(Error::Internal)?;
         Ok(PeerInfo {
             peer_id: l.peer_id,
             protocol_version: l.protocol_version,
@@ -102,9 +203,7 @@ impl IpfsDep for Api {
     /// Get information a peer.
     async fn lookup(&self, peer_id: PeerId) -> Result<PeerInfo, Error> {
         let l = self
-            .client()
-            .try_p2p()
-            .map_err(Error::Internal)?
+            .p2p
             .lookup(peer_id, None)
             .await
             .map_err(Error::Internal)?;
@@ -118,69 +217,51 @@ impl IpfsDep for Api {
     }
     async fn block_size(&self, cid: Cid) -> Result<u64, Error> {
         Ok(self
-            .client()
-            .try_store()
-            .map_err(Error::Internal)?
+            .store
             .get_size(cid)
             .await
             .map_err(Error::Internal)?
             .ok_or(Error::NotFound)?)
     }
     async fn block_get(&self, cid: Cid) -> Result<Bytes, Error> {
-        Ok(self.get_raw(cid).await.map_err(Error::Internal)?)
+        // TODO do we want to advertise on the DHT all Cids we have?
+        Ok(self.resolver.load_cid_bytes(cid).await?)
     }
     async fn get(&self, ipfs_path: &IpfsPath) -> Result<(Cid, Ipld), Error> {
-        let resolver = Resolver {
-            client: self.clone(),
-        };
-        let node = resolver.resolve(ipfs_path).await?;
+        // TODO do we want to advertise on the DHT all Cids we have?
+        let node = self.resolver.resolve(ipfs_path).await?;
         Ok((node.cid, node.data))
     }
     async fn put(&self, cid: Cid, blob: Bytes, links: Vec<Cid>) -> Result<(), Error> {
         // Advertise we provide the content
-        self.client()
-            .try_p2p()
-            .map_err(Error::Internal)?
+        self.p2p
             .start_providing(&cid)
             .await
             .map_err(Error::Internal)?;
         Ok(self
-            .client()
-            .try_store()
-            .map_err(Error::Internal)?
+            .store
             .put(cid, blob, links)
             .await
             .map_err(Error::Internal)?)
     }
     async fn resolve(&self, ipfs_path: &IpfsPath) -> Result<(Cid, String), Error> {
-        let resolver = Resolver {
-            client: self.clone(),
-        };
-        let node = resolver.resolve(ipfs_path).await?;
+        let node = self.resolver.resolve(ipfs_path).await?;
         Ok((node.cid, node.path.to_string_lossy().to_string()))
     }
     async fn peers(&self) -> Result<HashMap<PeerId, Vec<Multiaddr>>, Error> {
-        Ok(self
-            .client()
-            .try_p2p()
-            .map_err(Error::Internal)?
-            .get_peers()
-            .await
-            .map_err(Error::Internal)?)
+        Ok(self.p2p.get_peers().await.map_err(Error::Internal)?)
     }
     async fn connect(&self, peer_id: PeerId, addrs: Vec<Multiaddr>) -> Result<(), Error> {
         Ok(self
-            .client()
-            .try_p2p()
-            .map_err(Error::Internal)?
+            .p2p
             .connect(peer_id, addrs)
             .await
             .map_err(Error::Internal)?)
     }
     async fn publish(&self, topic: String, data: Bytes) -> Result<(), Error> {
-        self.p2p()
-            .map_err(Error::Internal)?
-            .publish(topic, data)
+        let topic = TopicHash::from_raw(topic);
+        self.p2p
+            .gossipsub_publish(topic, data)
             .await
             .map_err(Error::Internal)?;
         Ok(())
@@ -189,19 +270,17 @@ impl IpfsDep for Api {
         &self,
         topic: String,
     ) -> Result<BoxStream<'static, anyhow::Result<GossipsubEvent>>, Error> {
+        let topic = TopicHash::from_raw(topic);
         Ok(Box::pin(
-            self.p2p()
-                .map_err(Error::Internal)?
-                .subscribe(topic)
+            self.p2p
+                .gossipsub_subscribe(topic)
                 .await
                 .map_err(Error::Internal)?,
         ))
     }
     async fn topics(&self) -> Result<Vec<String>, Error> {
         Ok(self
-            .client()
-            .try_p2p()
-            .map_err(Error::Internal)?
+            .p2p
             .gossipsub_topics()
             .await
             .map_err(Error::Internal)?
@@ -217,7 +296,7 @@ impl IpfsDep for Api {
 // * dag-json
 // * dag-jose
 struct Resolver {
-    client: Api,
+    loader: Loader,
 }
 
 // Represents an IPFS DAG node
@@ -231,10 +310,11 @@ struct Node {
 }
 
 impl Resolver {
+    fn new(loader: Loader) -> Self {
+        Resolver { loader }
+    }
     async fn resolve(&self, path: &IpfsPath) -> Result<Node, Error> {
-        let root_cid = *path
-            .cid()
-            .ok_or_else(|| Error::Invalid(anyhow!("path must start with a CID")))?;
+        let root_cid = path.cid();
         let root = self.load_cid(root_cid).await?;
 
         let mut current = root;
@@ -272,8 +352,11 @@ impl Resolver {
         }
         Ok(current)
     }
+    async fn load_cid_bytes(&self, cid: Cid) -> Result<Bytes, Error> {
+        self.loader.load_cid(cid).await.map_err(Error::Internal)
+    }
     async fn load_cid(&self, cid: Cid) -> Result<Node, Error> {
-        let bytes = self.client.get_raw(cid).await.map_err(Error::Internal)?;
+        let bytes = self.load_cid_bytes(cid).await?;
         let data = match cid.codec() {
             //TODO(nathanielc): create constants for these
             // dag-cbor
@@ -292,5 +375,50 @@ impl Resolver {
         };
         let path = PathBuf::new();
         Ok(Node { cid, path, data })
+    }
+}
+
+/// Loader is responsible for fetching Cids.
+/// It tries local storage and then the network (via bitswap).
+struct Loader {
+    p2p: P2pClient,
+    store: StoreClient,
+}
+
+impl Loader {
+    // Load a Cid returning its bytes.
+    // If the Cid was not stored locally it will be added to the local store.
+    async fn load_cid(&self, cid: Cid) -> anyhow::Result<Bytes> {
+        trace!(%cid, "loading cid");
+
+        if let Some(loaded) = self.fetch_store(cid).await? {
+            return Ok(loaded);
+        }
+
+        let loaded = self.fetch_bitswap(cid).await?;
+
+        // Add loaded cid to the local store
+        self.store_data(cid, loaded.clone());
+        Ok(loaded)
+    }
+
+    async fn fetch_store(&self, cid: Cid) -> anyhow::Result<Option<Bytes>> {
+        self.store.get(cid).await
+    }
+    async fn fetch_bitswap(&self, cid: Cid) -> anyhow::Result<Bytes> {
+        // TODO can we check kad here and not use bitswap for content discovery?
+        self.p2p.fetch_bitswap(0, cid, Default::default()).await
+    }
+
+    fn store_data(&self, cid: Cid, data: Bytes) {
+        // trigger storage in the background
+        let store = self.store.clone();
+
+        tokio::spawn(async move {
+            match store.put(cid, data, vec![]).await {
+                Ok(_) => {}
+                Err(err) => error!(?err, "failed to put cid into local store"),
+            }
+        });
     }
 }

--- a/kubo-rpc/src/pin.rs
+++ b/kubo-rpc/src/pin.rs
@@ -1,8 +1,5 @@
 //! Implements the pin endpoints.
-use anyhow::anyhow;
-use iroh_api::{Cid, IpfsPath};
-
-use crate::{error::Error, IpfsDep};
+use crate::{error::Error, Cid, IpfsDep, IpfsPath};
 
 /// Add a DAG node to local store and mark it to not be garbaged collected.
 #[tracing::instrument(skip(client))]
@@ -24,12 +21,8 @@ pub async fn remove<T>(_client: T, ipfs_path: &IpfsPath) -> Result<Cid, Error>
 where
     T: IpfsDep,
 {
-    if let Some(cid) = ipfs_path.cid() {
-        // Beetle does not have any garbage collection for its store so everything is pinned.
-        // Therefore we do not need to track which blocks are pinned.
-        // Do nothing
-        Ok(*cid)
-    } else {
-        Err(Error::Invalid(anyhow!("IPFS path does not have a CID")))
-    }
+    // We do not have any garbage collection for its store so everything is pinned.
+    // Therefore we do not need to track which blocks are pinned.
+    // Do nothing
+    Ok(ipfs_path.cid())
 }

--- a/kubo-rpc/src/pubsub.rs
+++ b/kubo-rpc/src/pubsub.rs
@@ -1,9 +1,8 @@
 //! Publish Subscribe API
 
 use futures_util::stream::BoxStream;
-use iroh_api::{Bytes, GossipsubEvent};
 
-use crate::{error::Error, IpfsDep};
+use crate::{error::Error, Bytes, GossipsubEvent, IpfsDep};
 
 /// Publish a message to a topic
 #[tracing::instrument(skip(client, data))]

--- a/kubo-rpc/src/swarm.rs
+++ b/kubo-rpc/src/swarm.rs
@@ -1,9 +1,7 @@
 //! Implements the swarm related endpoints.
 use std::collections::BTreeMap;
 
-use iroh_api::{Multiaddr, PeerId};
-
-use crate::{error::Error, IpfsDep};
+use crate::{error::Error, IpfsDep, Multiaddr, PeerId};
 
 /// Report all connected peers of the current node.
 #[tracing::instrument(skip(client))]

--- a/one/Cargo.toml
+++ b/one/Cargo.toml
@@ -12,11 +12,14 @@ repository.workspace = true
 anyhow.workspace = true
 ceramic-kubo-rpc = { path = "../kubo-rpc", features = ["http"] }
 clap = { version = "4", features = ["derive", "env"] }
+futures.workspace = true
 futures-util.workspace = true
 git-version = "0.3"
 home = "0.5"
-iroh-api.workspace = true
-iroh-embed.workspace = true
+iroh-rpc-client.workspace = true
+iroh-rpc-types.workspace = true
+iroh-p2p.workspace = true
+iroh-store.workspace = true
 iroh-metrics.workspace = true
 libipld.workspace = true
 libp2p.workspace = true
@@ -32,6 +35,8 @@ tokio.workspace = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
+actix-http = { version = "3" }
+actix-web = { version = "4" }
 
 [dev-dependencies]
 expect-test = "1"

--- a/one/src/ipfs.rs
+++ b/one/src/ipfs.rs
@@ -59,8 +59,11 @@ impl Builder<Init> {
         };
 
         let rpc_addr = addr.clone();
-        let task =
-            tokio::spawn(async move { iroh_store::rpc::new(rpc_addr, store).await.unwrap() });
+        let task = tokio::spawn(async move {
+            if let Err(err) = iroh_store::rpc::new(rpc_addr, store).await {
+                error!("{:?}", err);
+            }
+        });
 
         Ok(Builder {
             state: WithStore {

--- a/one/src/ipfs.rs
+++ b/one/src/ipfs.rs
@@ -1,0 +1,166 @@
+//! API to create and manage an IPFS service.
+
+use anyhow::{Context, Result};
+use ceramic_kubo_rpc::IpfsService;
+use iroh_p2p::{Config as P2pConfig, DiskStorage, Keychain, Libp2pConfig, Node};
+use iroh_rpc_client::{P2pClient, StoreClient};
+use iroh_rpc_types::{p2p::P2pAddr, store::StoreAddr, Addr};
+use iroh_store::{Config as StoreConfig, Store};
+use std::{path::PathBuf, sync::Arc};
+use tokio::task::{self, JoinHandle};
+use tracing::{error, info};
+
+/// Builder provides an ordered API for constructing an Ipfs service.
+pub struct Builder<S: BuilderState> {
+    state: S,
+}
+
+/// The state of the builder
+pub trait BuilderState {}
+
+/// Initial state of the builder.
+pub struct Init {}
+impl BuilderState for Init {}
+
+/// A builder that has been configured with its store service.
+pub struct WithStore {
+    store: Service<StoreAddr>,
+}
+impl BuilderState for WithStore {}
+
+/// A builder that has been configured with its p2p service.
+pub struct WithP2p {
+    store: Service<StoreAddr>,
+    p2p: Service<P2pAddr>,
+}
+impl BuilderState for WithP2p {}
+
+/// Configure the local block store
+impl Builder<Init> {
+    pub async fn with_store(self, path: PathBuf) -> Result<Builder<WithStore>> {
+        let addr = Addr::new_mem();
+        let config = StoreConfig::with_rpc_addr(path, addr.clone());
+
+        // This is the file RocksDB itself is looking for to determine if the database already
+        // exists or not.  Just knowing the directory exists does not mean the database is
+        // created.
+        let marker = config.path.join("CURRENT");
+
+        let store = if marker.exists() {
+            info!("Opening store at {}", config.path.display());
+            Store::open(config)
+                .await
+                .context("failed to open existing store")?
+        } else {
+            info!("Creating store at {}", config.path.display());
+            Store::create(config)
+                .await
+                .context("failed to create new store")?
+        };
+
+        let rpc_addr = addr.clone();
+        let task =
+            tokio::spawn(async move { iroh_store::rpc::new(rpc_addr, store).await.unwrap() });
+
+        Ok(Builder {
+            state: WithStore {
+                store: Service { addr, task },
+            },
+        })
+    }
+}
+
+/// Configure the p2p service
+impl Builder<WithStore> {
+    pub async fn with_p2p(
+        self,
+        libp2p_config: Libp2pConfig,
+        key_store_path: PathBuf,
+    ) -> anyhow::Result<Builder<WithP2p>> {
+        let addr = Addr::new_mem();
+
+        let mut config = P2pConfig::default_with_rpc(addr.clone());
+
+        config.rpc_client.store_addr = Some(self.state.store.addr.clone());
+        config.libp2p = libp2p_config;
+        config.key_store_path = key_store_path;
+
+        let kc = Keychain::<DiskStorage>::new(config.key_store_path.clone()).await?;
+
+        let mut p2p = Node::new(config, addr.clone(), kc).await?;
+
+        let task = task::spawn(async move {
+            if let Err(err) = p2p.run().await {
+                error!("{:?}", err);
+            }
+        });
+
+        Ok(Builder {
+            state: WithP2p {
+                store: self.state.store,
+                p2p: Service { addr, task },
+            },
+        })
+    }
+}
+
+/// Finish the build
+impl Builder<WithP2p> {
+    pub async fn build(self) -> Result<Ipfs> {
+        Ok(Ipfs {
+            api: Arc::new(IpfsService::new(
+                P2pClient::new(self.state.p2p.addr.clone()).await?,
+                StoreClient::new(self.state.store.addr.clone()).await?,
+            )),
+            store: self.state.store,
+            p2p: self.state.p2p,
+        })
+    }
+}
+
+pub struct Ipfs {
+    api: Arc<IpfsService>,
+    p2p: Service<P2pAddr>,
+    store: Service<StoreAddr>,
+}
+
+impl Ipfs {
+    pub fn builder() -> Builder<Init> {
+        Builder { state: Init {} }
+    }
+    pub fn api(&self) -> Arc<IpfsService> {
+        self.api.clone()
+    }
+    pub async fn stop(self) -> Result<()> {
+        let p2p_res = self.p2p.stop().await;
+        let store_res = self.store.stop().await;
+        match (p2p_res, store_res) {
+            (Ok(_), Ok(_)) => Ok(()),
+            (e @ Err(_), _) => e,
+            (_, e @ Err(_)) => e,
+        }
+    }
+}
+
+struct Service<A> {
+    addr: A,
+    task: JoinHandle<()>,
+}
+
+impl<A> Service<A> {
+    async fn stop(mut self) -> Result<()> {
+        // This dummy task will be aborted by Drop.
+        let fut = futures::future::ready(());
+        let dummy_task = tokio::spawn(fut);
+        let task = std::mem::replace(&mut self.task, dummy_task);
+
+        task.abort();
+
+        // Because we currently don't do graceful termination we expect a cancelled error.
+        match task.await {
+            Ok(()) => Ok(()),
+            Err(err) if err.is_cancelled() => Ok(()),
+            Err(err) => Err(err.into()),
+        }
+    }
+}


### PR DESCRIPTION
This change exposes a Prometheus /metrics endpoint to enable metric collection via scraping.

Additionally a refactor to the how Beetle is consumed was performed. It was becoming very time consuming to trace Beetle code paths through many unneeded abstractions (i.e. unixfs). As such the refactor means that we now consume a minimal set of dependent crates from Beetle.

This has the advantage that is now very clear how these systems interact. For example publishing DHT records or when/how IPLD blocks are added to the local store.

Specifically we now depend on:

* iroh-metrics
* iroh-p2p
* iroh-rpc-client
* iroh-rpc-types
* iroh-store

Previously we were dependent on:

* iroh-api
* iroh-bitswap
* iroh-car
* iroh-embed
* iroh-gateway
* iroh-metrics
* iroh-one
* iroh-p2p
* iroh-resolver
* iroh-rpc-client
* iroh-rpc-types
* iroh-store
* iroh-unixfs
* iroh-util

This change comes with some small duplicated code to setup the p2p and store services. However this is a small amount of code with a clear purpose.