### PR TITLE
chore: only deny warnings during CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,25 @@
-FROM public.ecr.aws/r5b3e0r5/3box/rust-builder:latest as chef
+FROM public.ecr.aws/r5b3e0r5/3box/rust-builder:latest as builder
 
 RUN mkdir -p /home/builder/rust-ceramic
 WORKDIR /home/builder/rust-ceramic
 
-# TODO add to parent builder image
-RUN cargo install cargo-chef
+# Use the same ids as the parent docker image by default
+ARG UID=1001
+ARG GID=1001
 
-FROM chef AS planner
+# Copy in source code
 COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
 
-FROM chef AS builder
-COPY --from=planner /home/builder/rust-ceramic/recipe.json recipe.json
-
-# Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --recipe-path recipe.json
-
-# Build application
-COPY . .
-RUN make release
+# Build application using a docker cache
+# To clear the cache use:
+#   docker builder prune --filter type=exec.cachemount
+RUN --mount=type=cache,target=/home/builder/.cargo,uid=$UID,gid=$GID \
+	--mount=type=cache,target=/home/builder/rust-ceramic/target,uid=$UID,gid=$GID \
+    make release && \
+    cp ./target/release/ceramic-one ./
 
 FROM ubuntu:latest
 
-COPY --from=builder /home/builder/rust-ceramic/target/release/ceramic-one /usr/bin
+COPY --from=builder /home/builder/rust-ceramic/ceramic-one /usr/bin
 
 ENTRYPOINT ["/usr/bin/ceramic-one", "daemon"]

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build:
 
 .PHONY: release
 release:
-	cargo build -p ceramic-one --locked --release
+	RUSTFLAGS="-D warnings" cargo build -p ceramic-one --locked --release
 
 .PHONY: test
 test:

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,5 @@
 //! # Ceramic Core
 //! Core functionality for ceramic, including the StreamId, Cid, and Jws types.
-#![deny(warnings)]
 #![deny(missing_docs)]
 mod bytes;
 mod jwk;

--- a/event/src/lib.rs
+++ b/event/src/lib.rs
@@ -1,6 +1,5 @@
 //! # Ceramic Event
 //! Implementation of ceramic event protocol, with appropriate compatibilility with js-ceramic
-#![deny(warnings)]
 #![deny(missing_docs)]
 mod args;
 mod deterministic_init_event;

--- a/kubo-rpc/src/lib.rs
+++ b/kubo-rpc/src/lib.rs
@@ -4,7 +4,6 @@
 //! <https://docs.ipfs.tech/reference/kubo/rpc/>
 //!
 //! The http server implementation is behind the `http` feature.
-#![deny(warnings)]
 #![deny(missing_docs)]
 use std::{
     collections::HashMap,

--- a/one/src/main.rs
+++ b/one/src/main.rs
@@ -1,5 +1,4 @@
 //! Ceramic implements a single binary ceramic node.
-#![deny(warnings)]
 #![deny(missing_docs)]
 
 use std::{path::PathBuf, str::FromStr, sync::Arc, time::Duration};

--- a/recon/src/lib.rs
+++ b/recon/src/lib.rs
@@ -1,6 +1,5 @@
-#![deny(warnings, missing_docs, missing_debug_implementations, clippy::all)]
-
 //! Recon is a network protocol for set reconciliation
+#![deny(missing_docs)]
 
 pub use crate::recon::{Hash, Message, Recon};
 pub use ahash::AHash;


### PR DESCRIPTION
Additionally this change updates the Dockerfile to build using first class cache provided by Docker buildkit.