### PR TITLE
feat: implement libp2p Recon protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-global-executor"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +666,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
  "event-listener",
+]
+
+[[package]]
+name = "async-net"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4051e67316bc7eff608fe723df5d32ed639946adcd69e07df41fd42a7b411f1f"
+dependencies = [
+ "async-io",
+ "autocfg",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "autocfg",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2498,6 +2540,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3206,6 +3258,7 @@ dependencies = [
  "ipnet",
  "log",
  "rtnetlink",
+ "smol",
  "system-configuration",
  "tokio",
  "windows 0.34.0",
@@ -3334,7 +3387,6 @@ dependencies = [
 [[package]]
 name = "iroh-bitswap"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#8302eaaf9cdbda2ed30906307fad0fe195e3d7d6"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3373,7 +3425,6 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#8302eaaf9cdbda2ed30906307fad0fe195e3d7d6"
 dependencies = [
  "async-trait",
  "config",
@@ -3396,7 +3447,6 @@ dependencies = [
 [[package]]
 name = "iroh-p2p"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#8302eaaf9cdbda2ed30906307fad0fe195e3d7d6"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3439,7 +3489,6 @@ dependencies = [
 [[package]]
 name = "iroh-rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#8302eaaf9cdbda2ed30906307fad0fe195e3d7d6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3462,7 +3511,6 @@ dependencies = [
 [[package]]
 name = "iroh-rpc-types"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#8302eaaf9cdbda2ed30906307fad0fe195e3d7d6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3480,7 +3528,6 @@ dependencies = [
 [[package]]
 name = "iroh-store"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#8302eaaf9cdbda2ed30906307fad0fe195e3d7d6"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3514,7 +3561,6 @@ dependencies = [
 [[package]]
 name = "iroh-util"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#8302eaaf9cdbda2ed30906307fad0fe195e3d7d6"
 dependencies = [
  "anyhow",
  "cid 0.9.0",
@@ -4472,6 +4518,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-plaintext"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ff582c0b74ffda004b716b97bc9cfe7f39960204877758b876dde86093beaa8"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "log",
+ "quick-protobuf",
+ "unsigned-varint",
+ "void",
+]
+
+[[package]]
 name = "libp2p-quic"
 version = "0.7.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4567,11 +4630,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-swarm-test"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f6cb31f26505d134ce7106f419de02a8d9640ea56d92f751138933fbec8184d"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-plaintext",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-yamux",
+ "log",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "libp2p-tcp"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d33698596d7722d85d3ab0c86c2c322254fce1241e91208e3679b4eb3026cf"
 dependencies = [
+ "async-io",
  "futures",
  "futures-timer",
  "if-watch",
@@ -5145,6 +5228,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
 dependencies = [
+ "async-io",
  "bytes",
  "futures",
  "libc",
@@ -6090,6 +6174,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "quicksink"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6269,6 +6364,7 @@ name = "recon"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-std",
  "async-trait",
  "asynchronous-codec",
  "codespan-reporting",
@@ -6279,8 +6375,10 @@ dependencies = [
  "lalrpop-util",
  "libp2p",
  "libp2p-identity",
+ "libp2p-swarm-test",
  "multihash 0.18.1",
  "pretty",
+ "quickcheck",
  "rand 0.8.5",
  "regex",
  "rusqlite",
@@ -6290,6 +6388,7 @@ dependencies = [
  "serde_ipld_dagcbor",
  "serde_json",
  "tracing",
+ "tracing-test",
 ]
 
 [[package]]
@@ -6561,6 +6660,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
 dependencies = [
+ "async-global-executor",
  "futures",
  "log",
  "netlink-packet-route",
@@ -7042,6 +7142,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7137,6 +7247,23 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "smol"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13f2b548cd8447f8de0fdf1c592929f70f4fc7039a05e47404b0d096ec6987a1"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
 
 [[package]]
 name = "snow"
@@ -8153,6 +8280,29 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a2c0ff408fe918a94c428a3f2ad04e4afd5c95bbc08fcf868eff750c15728a4"
+dependencies = [
+ "lazy_static",
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
+dependencies = [
+ "lazy_static",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +733,9 @@ dependencies = [
  "futures-util",
  "memchr",
  "pin-project-lite 0.2.9",
+ "serde",
+ "serde_cbor",
+ "serde_json",
 ]
 
 [[package]]
@@ -874,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.64.0"
+version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
 dependencies = [
  "bitflags 1.3.2",
  "cexpr",
@@ -884,12 +893,13 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
+ "prettyplease 0.2.4",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1324,6 +1334,8 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "prometheus-client",
+ "rand 0.8.5",
+ "recon",
  "serde",
  "serde_json",
  "serde_repr",
@@ -1375,13 +1387,13 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "serde",
  "time 0.1.45",
@@ -2899,6 +2911,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3316,7 +3334,7 @@ dependencies = [
 [[package]]
 name = "iroh-bitswap"
 version = "0.2.0"
-source = "git+https://github.com/3box/beetle?branch=main#c44aae931a9e4673890efb6e632a033f4ae70e82"
+source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#8302eaaf9cdbda2ed30906307fad0fe195e3d7d6"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3334,6 +3352,7 @@ dependencies = [
  "iroh-util",
  "keyed_priority_queue",
  "libp2p",
+ "libp2p-identity",
  "multihash 0.17.0",
  "names",
  "num_enum",
@@ -3354,7 +3373,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.2.0"
-source = "git+https://github.com/3box/beetle?branch=main#c44aae931a9e4673890efb6e632a033f4ae70e82"
+source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#8302eaaf9cdbda2ed30906307fad0fe195e3d7d6"
 dependencies = [
  "async-trait",
  "config",
@@ -3377,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "iroh-p2p"
 version = "0.2.0"
-source = "git+https://github.com/3box/beetle?branch=main#c44aae931a9e4673890efb6e632a033f4ae70e82"
+source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#8302eaaf9cdbda2ed30906307fad0fe195e3d7d6"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3398,7 +3417,10 @@ dependencies = [
  "iroh-util",
  "lazy_static",
  "libp2p",
- "lru",
+ "libp2p-identity",
+ "libp2p-mplex",
+ "libp2p-quic",
+ "lru 0.8.1",
  "names",
  "rand 0.8.5",
  "serde",
@@ -3410,13 +3432,14 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "void",
  "zeroize",
 ]
 
 [[package]]
 name = "iroh-rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/3box/beetle?branch=main#c44aae931a9e4673890efb6e632a033f4ae70e82"
+source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#8302eaaf9cdbda2ed30906307fad0fe195e3d7d6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3439,7 +3462,7 @@ dependencies = [
 [[package]]
 name = "iroh-rpc-types"
 version = "0.2.0"
-source = "git+https://github.com/3box/beetle?branch=main#c44aae931a9e4673890efb6e632a033f4ae70e82"
+source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#8302eaaf9cdbda2ed30906307fad0fe195e3d7d6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3457,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "iroh-store"
 version = "0.2.0"
-source = "git+https://github.com/3box/beetle?branch=main#c44aae931a9e4673890efb6e632a033f4ae70e82"
+source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#8302eaaf9cdbda2ed30906307fad0fe195e3d7d6"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3491,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "iroh-util"
 version = "0.2.0"
-source = "git+https://github.com/3box/beetle?branch=main#c44aae931a9e4673890efb6e632a033f4ae70e82"
+source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#8302eaaf9cdbda2ed30906307fad0fe195e3d7d6"
 dependencies = [
  "anyhow",
  "cid 0.9.0",
@@ -4104,21 +4127,24 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libp2p"
-version = "0.50.1"
+version = "0.51.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7b0104790be871edcf97db9bd2356604984e623a08d825c3f27852290266b8"
+checksum = "f210d259724eae82005b5c48078619b7745edb7b76de370b03f8ba59ea103097"
 dependencies = [
  "bytes",
  "futures",
  "futures-timer",
  "getrandom 0.2.9",
  "instant",
+ "libp2p-allow-block-list",
  "libp2p-autonat",
+ "libp2p-connection-limits",
  "libp2p-core",
  "libp2p-dcutr",
  "libp2p-dns",
  "libp2p-gossipsub",
  "libp2p-identify",
+ "libp2p-identity",
  "libp2p-kad",
  "libp2p-mdns",
  "libp2p-metrics",
@@ -4134,93 +4160,107 @@ dependencies = [
  "libp2p-websocket",
  "libp2p-yamux",
  "multiaddr",
- "parking_lot 0.12.1",
  "pin-project",
- "smallvec",
+]
+
+[[package]]
+name = "libp2p-allow-block-list"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510daa05efbc25184458db837f6f9a5143888f1caa742426d92e1833ddd38a50"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "void",
 ]
 
 [[package]]
 name = "libp2p-autonat"
-version = "0.9.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705aa16b15f8438eea368b06cb0461ac885df35152b25ec31dfade1179a687cd"
+checksum = "f6ff5fc529665c9abf4e642fb28c0efd83536f6216cc3abf28e37a011a2d6dc5"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "instant",
  "libp2p-core",
+ "libp2p-identity",
  "libp2p-request-response",
  "libp2p-swarm",
  "log",
- "prost",
- "prost-build",
+ "quick-protobuf",
  "rand 0.8.5",
 ]
 
 [[package]]
-name = "libp2p-core"
-version = "0.38.0"
+name = "libp2p-connection-limits"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a8fcd392ff67af6cc3f03b1426c41f7f26b6b9aff2dc632c1c56dd649e571f"
+checksum = "4caa33f1d26ed664c4fe2cca81a08c8e07d4c1c04f2f4ac7655c2dd85467fda0"
 dependencies = [
- "asn1_der",
- "bs58",
- "ed25519-dalek",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "void",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1df63c0b582aa434fb09b2d86897fa2b419ffeccf934b36f87fcedc8e835c2"
+dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
  "instant",
+ "libp2p-identity",
  "log",
  "multiaddr",
- "multihash 0.16.3",
+ "multihash 0.17.0",
  "multistream-select",
  "once_cell",
  "parking_lot 0.12.1",
  "pin-project",
- "prost",
- "prost-build",
+ "quick-protobuf",
  "rand 0.8.5",
- "ring",
  "rw-stream-sink",
- "sec1",
  "serde",
- "sha2 0.10.6",
  "smallvec",
  "thiserror",
  "unsigned-varint",
  "void",
- "zeroize",
 ]
 
 [[package]]
 name = "libp2p-dcutr"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c642470f6ca6301cb607806c7c045b1e70010659422ec775367fc334147fa28a"
+checksum = "0a8854d223a4145d7cf0652553fe606df397cfd96f9bb7f62d7d0a2b2332ca1b"
 dependencies = [
  "asynchronous-codec",
- "bytes",
  "either",
  "futures",
  "futures-timer",
  "instant",
  "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm",
  "log",
- "prost",
- "prost-build",
- "prost-codec",
+ "quick-protobuf",
+ "quick-protobuf-codec",
  "thiserror",
  "void",
 ]
 
 [[package]]
 name = "libp2p-dns"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e42a271c1b49f789b92f7fc87749fa79ce5c7bdc88cbdfacb818a4bca47fec5"
+checksum = "146ff7034daae62077c415c2376b8057368042df6ab95f5432ad5e88568b1554"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -4232,25 +4272,26 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.43.0"
+version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a173171c71c29bb156f98886c7c4824596de3903dadf01e2e79d2ccdcf38cd9f"
+checksum = "70b34b6da8165c0bde35c82db8efda39b824776537e73973549e76cadb3a77c5"
 dependencies = [
  "asynchronous-codec",
- "base64 0.13.1",
+ "base64 0.21.0",
  "byteorder",
  "bytes",
+ "either",
  "fnv",
  "futures",
  "hex_fmt",
  "instant",
  "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm",
  "log",
  "prometheus-client",
- "prost",
- "prost-build",
- "prost-codec",
+ "quick-protobuf",
+ "quick-protobuf-codec",
  "rand 0.8.5",
  "regex",
  "serde",
@@ -4258,35 +4299,58 @@ dependencies = [
  "smallvec",
  "thiserror",
  "unsigned-varint",
+ "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.41.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c052d0026f4817b44869bfb6810f4e1112f43aec8553f2cb38881c524b563abf"
+checksum = "5455f472243e63b9c497ff320ded0314254a9eb751799a39c283c6f20b793f3c"
 dependencies = [
  "asynchronous-codec",
+ "either",
  "futures",
  "futures-timer",
  "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm",
  "log",
- "lru",
- "prost",
- "prost-build",
- "prost-codec",
+ "lru 0.10.0",
+ "quick-protobuf",
+ "quick-protobuf-codec",
  "smallvec",
  "thiserror",
  "void",
 ]
 
 [[package]]
-name = "libp2p-kad"
-version = "0.42.1"
+name = "libp2p-identity"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2766dcd2be8c87d5e1f35487deb22d765f49c6ae1251b3633efe3b25698bd3d2"
+checksum = "9e2d584751cecb2aabaa56106be6be91338a60a0f4e420cf2af639204f596fc1"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "log",
+ "multiaddr",
+ "multihash 0.17.0",
+ "quick-protobuf",
+ "rand 0.8.5",
+ "ring",
+ "serde",
+ "sha2 0.10.6",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-kad"
+version = "0.43.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39d5ef876a2b2323d63c258e63c2f8e36f205fe5a11f0b3095d59635650790ff"
 dependencies = [
  "arrayvec 0.7.2",
  "asynchronous-codec",
@@ -4297,10 +4361,10 @@ dependencies = [
  "futures-timer",
  "instant",
  "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm",
  "log",
- "prost",
- "prost-build",
+ "quick-protobuf",
  "rand 0.8.5",
  "serde",
  "sha2 0.10.6",
@@ -4313,14 +4377,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.42.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f378264aade9872d6ccd315c0accc18be3a35d15fc1b9c36e5b6f983b62b5b"
+checksum = "19983e1f949f979a928f2c603de1cf180cc0dc23e4ac93a62651ccb18341460b"
 dependencies = [
  "data-encoding",
  "futures",
  "if-watch",
  "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm",
  "log",
  "rand 0.8.5",
@@ -4333,9 +4398,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad8a64f29da86005c86a4d2728b8a0719e9b192f4092b609fd8790acb9dec55"
+checksum = "a42ec91e227d7d0dafa4ce88b333cdf5f277253873ab087555c92798db2ddd46"
 dependencies = [
  "libp2p-core",
  "libp2p-dcutr",
@@ -4350,9 +4415,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03805b44107aa013e7cbbfa5627b31c36cbedfdfb00603c0311998882bc4bace"
+checksum = "4d34780b514b159e6f3fd70ba3e72664ec89da28dca2d1e7856ee55e2c7031ba"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4368,18 +4433,18 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.41.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978cb57efe82e892ec6f348a536bfbd9fee677adbe5689d7a93ad3a9bffbf2e"
+checksum = "9c3673da89d29936bc6435bafc638e2f184180d554ce844db65915113f86ec5e"
 dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
  "futures",
  "libp2p-core",
+ "libp2p-identity",
  "log",
  "once_cell",
- "prost",
- "prost-build",
+ "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.6",
  "snow",
@@ -4391,10 +4456,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "929fcace45a112536e22b3dcfd4db538723ef9c3cb79f672b98be2cc8e25f37f"
+checksum = "3e57759c19c28a73ef1eb3585ca410cefb72c1a709fcf6de1612a378e4219202"
 dependencies = [
+ "either",
  "futures",
  "futures-timer",
  "instant",
@@ -4407,15 +4473,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.7.0-alpha"
+version = "0.7.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e7c867e95c8130667b24409d236d37598270e6da69b3baf54213ba31ffca59"
+checksum = "c6b26abd81cd2398382a1edfe739b539775be8a90fa6914f39b2ab49571ec735"
 dependencies = [
  "bytes",
  "futures",
  "futures-timer",
  "if-watch",
  "libp2p-core",
+ "libp2p-identity",
  "libp2p-tls",
  "log",
  "parking_lot 0.12.1",
@@ -4428,9 +4495,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.14.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffb67f6b6cce19cfeab9b10b77fbff756a66a1c143cba7deb8c3f964fadcb59"
+checksum = "23f34cef39bbc4d020a1e538e2af2bdd707143569de87e7ce6f1500373db0b41"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4439,14 +4506,12 @@ dependencies = [
  "futures-timer",
  "instant",
  "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm",
  "log",
- "pin-project",
- "prost",
- "prost-build",
- "prost-codec",
+ "quick-protobuf",
+ "quick-protobuf-codec",
  "rand 0.8.5",
- "smallvec",
  "static_assertions",
  "thiserror",
  "void",
@@ -4454,49 +4519,47 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3236168796727bfcf4927f766393415361e2c644b08bedb6a6b13d957c9a4884"
+checksum = "7ffdb374267d42dc5ed5bc53f6e601d4a64ac5964779c6e40bb9e4f14c1e30d5"
 dependencies = [
  "async-trait",
- "bytes",
  "futures",
  "instant",
  "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm",
- "log",
  "rand 0.8.5",
  "smallvec",
- "unsigned-varint",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.41.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a35472fe3276b3855c00f1c032ea8413615e030256429ad5349cdf67c6e1a0"
+checksum = "903b3d592d7694e56204d211f29d31bc004be99386644ba8731fc3e3ef27b296"
 dependencies = [
+ "async-std",
  "either",
  "fnv",
  "futures",
  "futures-timer",
  "instant",
  "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm-derive",
  "log",
- "pin-project",
  "rand 0.8.5",
  "smallvec",
- "thiserror",
  "tokio",
  "void",
 ]
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d527d5827582abd44a6d80c07ff8b50b4ee238a8979e05998474179e79dc400"
+checksum = "0fba456131824ab6acd4c7bf61e9c0f0a3014b5fc9868ccb8e10d344594cdc4f"
 dependencies = [
  "heck",
  "quote",
@@ -4505,9 +4568,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b257baf6df8f2df39678b86c578961d48cc8b68642a12f0f763f56c8e5858d"
+checksum = "33d33698596d7722d85d3ab0c86c2c322254fce1241e91208e3679b4eb3026cf"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4521,13 +4584,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tls"
-version = "0.1.0-alpha"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7905ce0d040576634e8a3229a7587cc8beab83f79db6023800f1792895defa8"
+checksum = "ff08d13d0dc66e5e9ba6279c1de417b84fa0d0adc3b03e5732928c180ec02781"
 dependencies = [
  "futures",
  "futures-rustls",
  "libp2p-core",
+ "libp2p-identity",
  "rcgen 0.10.0",
  "ring",
  "rustls 0.20.8",
@@ -4539,9 +4603,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webrtc"
-version = "0.4.0-alpha"
+version = "0.4.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb6cd86dd68cba72308ea05de1cebf3ba0ae6e187c40548167955d4e3970f6a"
+checksum = "dba48592edbc2f60b4bc7c10d65445b0c3964c07df26fdf493b6880d33be36f8"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -4551,12 +4615,12 @@ dependencies = [
  "hex",
  "if-watch",
  "libp2p-core",
+ "libp2p-identity",
  "libp2p-noise",
  "log",
- "multihash 0.16.3",
- "prost",
- "prost-build",
- "prost-codec",
+ "multihash 0.17.0",
+ "quick-protobuf",
+ "quick-protobuf-codec",
  "rand 0.8.5",
  "rcgen 0.9.3",
  "serde",
@@ -4570,9 +4634,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d705506030d5c0aaf2882437c70dab437605f21c5f9811978f694e6917a3b54"
+checksum = "111273f7b3d3510524c752e8b7a5314b7f7a1fee7e68161c01a7d72cbb06db9f"
 dependencies = [
  "either",
  "futures",
@@ -4589,23 +4653,22 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.42.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f63594a0aa818642d9d4915c791945053877253f08a3626f13416b5cd928a29"
+checksum = "4dcd21d950662700a385d4c6d68e2f5f54d778e97068cdd718522222ef513bda"
 dependencies = [
  "futures",
  "libp2p-core",
  "log",
- "parking_lot 0.12.1",
  "thiserror",
  "yamux",
 ]
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.8.3+7.4.4"
+version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557b255ff04123fcc176162f56ed0c9cd42d8f357cf55b3fabeb60f7413741b3"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -4613,6 +4676,7 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
+ "lz4-sys",
  "zstd-sys",
 ]
 
@@ -4728,12 +4792,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
+dependencies = [
+ "hashbrown 0.13.2",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -4856,15 +4939,16 @@ checksum = "e7627d8bbeb17edbf1c3f74b21488e4af680040da89713b4217d0010e9cbd97e"
 
 [[package]]
 name = "multiaddr"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aebdb21e90f81d13ed01dc84123320838e53963c2ca94b60b305d3fa64f31e"
+checksum = "2b36f567c7099511fa8612bbbb52dda2419ce0bdbacf31714e3a5ffdb766d3bd"
 dependencies = [
  "arrayref",
  "byteorder",
  "data-encoding",
+ "log",
  "multibase 0.9.1",
- "multihash 0.16.3",
+ "multihash 0.17.0",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -5795,6 +5879,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5855,21 +5949,21 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83cd1b99916654a69008fd66b4f9397fbe08e6e51dfe23d4417acf5d3b8cb87c"
+checksum = "5d6fa99d535dd930d1249e6c79cb3c2915f9172a540fe2b02a4c8f9ca954721e"
 dependencies = [
  "dtoa",
  "itoa",
  "parking_lot 0.12.1",
- "prometheus-client-derive-text-encode",
+ "prometheus-client-derive-encode",
 ]
 
 [[package]]
-name = "prometheus-client-derive-text-encode"
-version = "0.3.0"
+name = "prometheus-client-derive-encode"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a455fbcb954c1a7decf3c586e860fd7889cddf4b8e164be736dbac95a953cd"
+checksum = "72b6a5217beb0ad503ee7fa752d451c905113d70721b937126158f3106a48cc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5899,26 +5993,13 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
+ "prettyplease 0.1.25",
  "prost",
  "prost-types",
  "regex",
  "syn 1.0.109",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-codec"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc34979ff898b6e141106178981ce2596c387ea6e62533facfc61a37fc879c0"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "prost",
- "thiserror",
- "unsigned-varint",
 ]
 
 [[package]]
@@ -5985,6 +6066,28 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-protobuf"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "quick-protobuf-codec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1693116345026436eb2f10b677806169c1a1260c1c60eaaffe3fb5a29ae23d8b"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "quick-protobuf",
+ "thiserror",
+ "unsigned-varint",
+]
 
 [[package]]
 name = "quicksink"
@@ -6165,19 +6268,28 @@ dependencies = [
 name = "recon"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
+ "asynchronous-codec",
  "codespan-reporting",
  "expect-test",
  "hex",
+ "iroh-p2p",
  "lalrpop",
  "lalrpop-util",
+ "libp2p",
+ "libp2p-identity",
  "multihash 0.18.1",
  "pretty",
+ "rand 0.8.5",
  "regex",
  "rusqlite",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "serde_ipld_dagcbor",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -6372,9 +6484,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -6712,6 +6824,16 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
  "serde",
 ]
 
@@ -7895,7 +8017,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.1.25",
  "proc-macro2",
  "prost-build",
  "quote",
@@ -8232,8 +8354,6 @@ checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "futures-io",
- "futures-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3387,6 +3387,7 @@ dependencies = [
 [[package]]
 name = "iroh-bitswap"
 version = "0.2.0"
+source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#e858d9813ae1538f52f9257dde832a920be064cf"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3425,6 +3426,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.2.0"
+source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#e858d9813ae1538f52f9257dde832a920be064cf"
 dependencies = [
  "async-trait",
  "config",
@@ -3447,6 +3449,7 @@ dependencies = [
 [[package]]
 name = "iroh-p2p"
 version = "0.2.0"
+source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#e858d9813ae1538f52f9257dde832a920be064cf"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3489,6 +3492,7 @@ dependencies = [
 [[package]]
 name = "iroh-rpc-client"
 version = "0.2.0"
+source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#e858d9813ae1538f52f9257dde832a920be064cf"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3511,6 +3515,7 @@ dependencies = [
 [[package]]
 name = "iroh-rpc-types"
 version = "0.2.0"
+source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#e858d9813ae1538f52f9257dde832a920be064cf"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3528,6 +3533,7 @@ dependencies = [
 [[package]]
 name = "iroh-store"
 version = "0.2.0"
+source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#e858d9813ae1538f52f9257dde832a920be064cf"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3561,6 +3567,7 @@ dependencies = [
 [[package]]
 name = "iroh-util"
 version = "0.2.0"
+source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#e858d9813ae1538f52f9257dde832a920be064cf"
 dependencies = [
  "anyhow",
  "cid 0.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "iroh-bitswap"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#e858d9813ae1538f52f9257dde832a920be064cf"
+source = "git+https://github.com/3box/beetle?branch=main#7a9f48e5d028645e3179f3c60e84eab7f39fdfef"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3426,7 +3426,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#e858d9813ae1538f52f9257dde832a920be064cf"
+source = "git+https://github.com/3box/beetle?branch=main#7a9f48e5d028645e3179f3c60e84eab7f39fdfef"
 dependencies = [
  "async-trait",
  "config",
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "iroh-p2p"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#e858d9813ae1538f52f9257dde832a920be064cf"
+source = "git+https://github.com/3box/beetle?branch=main#7a9f48e5d028645e3179f3c60e84eab7f39fdfef"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3492,7 +3492,7 @@ dependencies = [
 [[package]]
 name = "iroh-rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#e858d9813ae1538f52f9257dde832a920be064cf"
+source = "git+https://github.com/3box/beetle?branch=main#7a9f48e5d028645e3179f3c60e84eab7f39fdfef"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3515,7 +3515,7 @@ dependencies = [
 [[package]]
 name = "iroh-rpc-types"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#e858d9813ae1538f52f9257dde832a920be064cf"
+source = "git+https://github.com/3box/beetle?branch=main#7a9f48e5d028645e3179f3c60e84eab7f39fdfef"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "iroh-store"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#e858d9813ae1538f52f9257dde832a920be064cf"
+source = "git+https://github.com/3box/beetle?branch=main#7a9f48e5d028645e3179f3c60e84eab7f39fdfef"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -3567,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "iroh-util"
 version = "0.2.0"
-source = "git+https://github.com/nathanielc/beetle?branch=custom-behaviour#e858d9813ae1538f52f9257dde832a920be064cf"
+source = "git+https://github.com/3box/beetle?branch=main#7a9f48e5d028645e3179f3c60e84eab7f39fdfef"
 dependencies = [
  "anyhow",
  "cid 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,20 @@ dag-jose = "0.1"
 futures = "0.3"
 futures-util = "0.3"
 hex = "0.4.3"
-iroh-metrics = { git = "https://github.com/3box/beetle", branch = "main" }
-iroh-p2p = { git = "https://github.com/3box/beetle", branch = "main" }
-iroh-rpc-client = { git = "https://github.com/3box/beetle", branch = "main" }
-iroh-rpc-types = { git = "https://github.com/3box/beetle", branch = "main" }
-iroh-store = { git = "https://github.com/3box/beetle", branch = "main" }
-libipld = "0.15"                                                               # use same version as Iroh
-libp2p = { version = "0.50", default-features = false }                        # use same version as Iroh
-libp2p-tls = { version = "=0.1.0-alpha", default-features = false }            # use explicit version of dep to avoid conflict
-multiaddr = "0.16"                                                             # use same version as Iroh
+iroh-metrics = { git = "https://github.com/nathanielc/beetle", branch = "custom-behaviour" }
+iroh-p2p = { git = "https://github.com/nathanielc/beetle", branch = "custom-behaviour" }
+iroh-rpc-client = { git = "https://github.com/nathanielc/beetle", branch = "custom-behaviour" }
+iroh-rpc-types = { git = "https://github.com/nathanielc/beetle", branch = "custom-behaviour" }
+iroh-store = { git = "https://github.com/nathanielc/beetle", branch = "custom-behaviour" }
+libipld = "0.15" # use same version as Iroh
+libp2p = { version = "0.51", default-features = false, features = [
+    "request-response",
+] } # use same version as Iroh
+libp2p-tls = { version = "0.1.0", default-features = false } # use explicit version of dep to avoid conflict
+multiaddr = "0.17" # use same version as Iroh
 multibase = "0.9"
 multihash = "0.17"
+recon = { path = "./recon/" }
 once_cell = "1.17.1"
 opentelemetry = "0.18"
 opentelemetry-otlp = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,10 @@ iroh-p2p = { git = "https://github.com/nathanielc/beetle", branch = "custom-beha
 iroh-rpc-client = { git = "https://github.com/nathanielc/beetle", branch = "custom-behaviour" }
 iroh-rpc-types = { git = "https://github.com/nathanielc/beetle", branch = "custom-behaviour" }
 iroh-store = { git = "https://github.com/nathanielc/beetle", branch = "custom-behaviour" }
-libipld = "0.15" # use same version as Iroh
-libp2p = { version = "0.51", default-features = false, features = [
-    "request-response",
-] } # use same version as Iroh
-libp2p-tls = { version = "0.1.0", default-features = false } # use explicit version of dep to avoid conflict
-multiaddr = "0.17" # use same version as Iroh
+libipld = "0.15"                                                                                # use same version as Iroh
+libp2p = { version = "0.51", default-features = false }                                         # use same version as Iroh
+libp2p-tls = { version = "0.1.0", default-features = false }                                    # use explicit version of dep to avoid conflict
+multiaddr = "0.17"                                                                              # use same version as Iroh
 multibase = "0.9"
 multihash = "0.17"
 recon = { path = "./recon/" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,18 +37,19 @@ tokio = { version = "1", default-features = false, features = ["rt"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.18"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-test = { version = "0.2" }
 unimock = "0.4"
 unsigned-varint = "0.7"
 expect-test = "1"
 
 
 # Uncomment these lines to use a local copy of beetle
-#[patch."https://github.com/3box/beetle"]
-#iroh-metrics = { path = "../beetle/iroh-metrics" }
-#iroh-p2p = { path = "../beetle/iroh-p2p" }
-#iroh-rpc-client = { path = "../beetle/iroh-rpc-client" }
-#iroh-rpc-types = { path = "../beetle/iroh-rpc-types" }
-#iroh-store = { path = "../beetle/iroh-store" }
+[patch."https://github.com/nathanielc/beetle"]
+iroh-metrics = { path = "../beetle/iroh-metrics" }
+iroh-p2p = { path = "../beetle/iroh-p2p" }
+iroh-rpc-client = { path = "../beetle/iroh-rpc-client" }
+iroh-rpc-types = { path = "../beetle/iroh-rpc-types" }
+iroh-store = { path = "../beetle/iroh-store" }
 
 #[patch.crates-io]
 #libp2p = { path = "../rust-libp2p/libp2p" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,15 @@ dag-jose = "0.1"
 futures = "0.3"
 futures-util = "0.3"
 hex = "0.4.3"
-iroh-metrics = { git = "https://github.com/nathanielc/beetle", branch = "custom-behaviour" }
-iroh-p2p = { git = "https://github.com/nathanielc/beetle", branch = "custom-behaviour" }
-iroh-rpc-client = { git = "https://github.com/nathanielc/beetle", branch = "custom-behaviour" }
-iroh-rpc-types = { git = "https://github.com/nathanielc/beetle", branch = "custom-behaviour" }
-iroh-store = { git = "https://github.com/nathanielc/beetle", branch = "custom-behaviour" }
-libipld = "0.15"                                                                                # use same version as Iroh
-libp2p = { version = "0.51", default-features = false }                                         # use same version as Iroh
-libp2p-tls = { version = "0.1.0", default-features = false }                                    # use explicit version of dep to avoid conflict
-multiaddr = "0.17"                                                                              # use same version as Iroh
+iroh-metrics = { git = "https://github.com/3box/beetle", branch = "main" }
+iroh-p2p = { git = "https://github.com/3box/beetle", branch = "main" }
+iroh-rpc-client = { git = "https://github.com/3box/beetle", branch = "main" }
+iroh-rpc-types = { git = "https://github.com/3box/beetle", branch = "main" }
+iroh-store = { git = "https://github.com/3box/beetle", branch = "main" }
+libipld = "0.15"                                                               # use same version as Iroh
+libp2p = { version = "0.51", default-features = false }                        # use same version as Iroh
+libp2p-tls = { version = "0.1.0", default-features = false }                   # use explicit version of dep to avoid conflict
+multiaddr = "0.17"                                                             # use same version as Iroh
 multibase = "0.9"
 multihash = "0.17"
 recon = { path = "./recon/" }
@@ -51,8 +51,6 @@ expect-test = "1"
 #iroh-rpc-types = { path = "../beetle/iroh-rpc-types" }
 #iroh-store = { path = "../beetle/iroh-store" }
 
-#[patch.crates-io]
-#libp2p = { path = "../rust-libp2p/libp2p" }
 
 [workspace.package]
 version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,12 +44,12 @@ expect-test = "1"
 
 
 # Uncomment these lines to use a local copy of beetle
-[patch."https://github.com/nathanielc/beetle"]
-iroh-metrics = { path = "../beetle/iroh-metrics" }
-iroh-p2p = { path = "../beetle/iroh-p2p" }
-iroh-rpc-client = { path = "../beetle/iroh-rpc-client" }
-iroh-rpc-types = { path = "../beetle/iroh-rpc-types" }
-iroh-store = { path = "../beetle/iroh-store" }
+#[patch."https://github.com/nathanielc/beetle"]
+#iroh-metrics = { path = "../beetle/iroh-metrics" }
+#iroh-p2p = { path = "../beetle/iroh-p2p" }
+#iroh-rpc-client = { path = "../beetle/iroh-rpc-client" }
+#iroh-rpc-types = { path = "../beetle/iroh-rpc-types" }
+#iroh-store = { path = "../beetle/iroh-store" }
 
 #[patch.crates-io]
 #libp2p = { path = "../rust-libp2p/libp2p" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /home/builder/rust-ceramic
 ARG UID=1001
 ARG GID=1001
 
+# Define the type of build to make. One of release or debug.
+ARG BUILD_MODE=release
+
 # Copy in source code
 COPY . .
 
@@ -15,7 +18,7 @@ COPY . .
 #   docker builder prune --filter type=exec.cachemount
 RUN --mount=type=cache,target=/home/builder/.cargo,uid=$UID,gid=$GID \
 	--mount=type=cache,target=/home/builder/rust-ceramic/target,uid=$UID,gid=$GID \
-    make release && \
+    make $BUILD_MODE && \
     cp ./target/release/ceramic-one ./
 
 FROM ubuntu:latest

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ build:
 release:
 	RUSTFLAGS="-D warnings" cargo build -p ceramic-one --locked --release
 
+.PHONY: debug
+debug:
+	cargo build -p ceramic-one --locked
+
 .PHONY: test
 test:
 	# Test with default features

--- a/kubo-rpc/src/http/pubsub.rs
+++ b/kubo-rpc/src/http/pubsub.rs
@@ -3,7 +3,7 @@ use actix_web::{http::header::ContentType, web, HttpResponse, Scope};
 use anyhow::anyhow;
 use futures_util::StreamExt;
 use libipld::multibase::{self, Base};
-use libp2p::gossipsub::GossipsubMessage;
+use libp2p::gossipsub::Message;
 use serde::{Deserialize, Serialize};
 
 use crate::{error::Error, http::AppState, pubsub, Bytes, GossipsubEvent, IpfsDep};
@@ -127,7 +127,7 @@ where
                     from: _,
                     id: _,
                     message:
-                        GossipsubMessage {
+                        Message {
                             source,
                             data,
                             sequence_number,
@@ -173,7 +173,7 @@ mod tests {
     use expect_test::expect;
     use futures_util::{stream::BoxStream, StreamExt};
     use libipld::multibase::{self, Base};
-    use libp2p::gossipsub::{GossipsubMessage, TopicHash};
+    use libp2p::gossipsub::{Message, TopicHash};
     use unimock::MockFn;
     use unimock::{matching, Unimock};
 
@@ -299,7 +299,7 @@ mod tests {
                     from: PeerId::from_str("12D3KooWHUfjwiTRVV8jxFcKRSQTPatayC4nQCNX86oxRF5XWzGe")
                         .unwrap(),
                     id: libp2p::gossipsub::MessageId::new(&[]),
-                    message: GossipsubMessage {
+                    message: Message {
                         source: Some(
                             PeerId::from_str(
                                 "12D3KooWM68GyFKBT9JsuTRB6CYkF61PtMuSkynUauSQEGBX51JW",
@@ -315,7 +315,7 @@ mod tests {
                     from: PeerId::from_str("12D3KooWGnKwtpSh2ZLTvoC8mjiexMNRLNkT92pxq7MDgyJHktNJ")
                         .unwrap(),
                     id: libp2p::gossipsub::MessageId::new(&[]),
-                    message: GossipsubMessage {
+                    message: Message {
                         source: Some(
                             PeerId::from_str(
                                 "12D3KooWQVU9Pv3BqD6bD9w96tJxLedKCj4VZ75oqX9Tav4R4rUS",

--- a/one/Cargo.toml
+++ b/one/Cargo.toml
@@ -27,7 +27,8 @@ multiaddr.workspace = true
 names = "0.14"
 opentelemetry-otlp.workspace = true
 opentelemetry.workspace = true
-prometheus-client = "0.18"
+prometheus-client = "0.19"
+recon.workspace = true
 serde = "1"
 serde_json = "1"
 serde_repr = "0.1"
@@ -37,6 +38,7 @@ tracing-subscriber.workspace = true
 tracing.workspace = true
 actix-http = { version = "3" }
 actix-web = { version = "4" }
+rand = "0.8.5"
 
 [dev-dependencies]
 expect-test = "1"

--- a/one/src/main.rs
+++ b/one/src/main.rs
@@ -173,22 +173,9 @@ impl Daemon {
             .collect::<Result<Vec<Multiaddr>, multiaddr::Error>>()?;
         debug!(?p2p_config, "using p2p config");
 
-        // TODO remove this demo code
-        // Generates a set of random keys to synchronize using Recon
-        let mut set = std::collections::BTreeSet::new();
-        for _ in 0..100 {
-            use rand::{distributions::Alphanumeric, Rng}; // 0.8
-            let s: String = rand::thread_rng()
-                .sample_iter(&Alphanumeric)
-                .take(12)
-                .map(char::from)
-                .collect();
-            set.insert(s);
-        }
-
         // Construct a recon implementation.
-        let recon = Arc::new(std::sync::Mutex::new(recon::Recon::from_set(set)));
-        let recon = recon::libp2p::Behaviour::new(recon);
+        let recon = Arc::new(std::sync::Mutex::new(recon::Recon::from_set([].into())));
+        let recon = recon::libp2p::Behaviour::new(recon, recon::libp2p::Config::default());
 
         let ipfs = Ipfs::builder()
             .with_store(dir.join("store"))

--- a/one/src/metrics.rs
+++ b/one/src/metrics.rs
@@ -4,18 +4,18 @@ use actix_web::{dev::Server, get, http::header::ContentType, App, HttpResponse, 
 use anyhow::Result;
 use ceramic_kubo_rpc::PeerId;
 use libp2p::metrics::Recorder;
-use prometheus_client::metrics::counter::Counter;
 use prometheus_client::registry::Registry;
-use prometheus_client::{encoding::text::Encode, metrics::family::Family};
+use prometheus_client::{encoding::EncodeLabelSet, metrics::counter::Counter};
+use prometheus_client::{encoding::EncodeLabelValue, metrics::family::Family};
 
 use crate::pubsub;
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct MsgLabels {
     msg_type: MsgType,
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
 enum MsgType {
     Update,
     Query,
@@ -23,18 +23,18 @@ enum MsgType {
     Keepalive,
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct PeerLabels {
     peer_id: String,
     version: String,
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct TipLoadLabels {
     result: TipLoadResult,
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
 pub enum TipLoadResult {
     Success,
     Failure,
@@ -78,18 +78,18 @@ impl Metrics {
         sub_registry.register(
             "pubsub_messages",
             "Number of ceramic pubsub messages received",
-            Box::new(messages.clone()),
+            messages.clone(),
         );
 
         let peers = Family::<PeerLabels, Counter>::default();
         sub_registry.register(
             "peers",
             "Number of keepalive messages from each peer, useful for understanding network topology",
-            Box::new(peers.clone()),
+            peers.clone(),
         );
 
         let tip_loads = Family::<TipLoadLabels, Counter>::default();
-        sub_registry.register("tip_loads", "Number tip loads", Box::new(tip_loads.clone()));
+        sub_registry.register("tip_loads", "Number tip loads", tip_loads.clone());
 
         Self {
             messages,

--- a/one/src/network.rs
+++ b/one/src/network.rs
@@ -80,7 +80,7 @@ impl Builder<WithStore> {
         self,
         libp2p_config: Libp2pConfig,
         key_store_path: PathBuf,
-        behvaiour: B,
+        behaviour: B,
     ) -> anyhow::Result<Builder<WithP2p>>
     where
         B: NetworkBehaviour + Send,
@@ -97,7 +97,7 @@ impl Builder<WithStore> {
 
         let kc = Keychain::<DiskStorage>::new(config.key_store_path.clone()).await?;
 
-        let mut p2p = Node::new(config, addr.clone(), kc, Some(behvaiour)).await?;
+        let mut p2p = Node::new(config, addr.clone(), kc, Some(behaviour)).await?;
 
         let task = task::spawn(async move {
             if let Err(err) = p2p.run().await {

--- a/recon/Cargo.toml
+++ b/recon/Cargo.toml
@@ -8,12 +8,20 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
 hex = "0.4.3"
 multihash = "0.18.0"
 serde.workspace = true
 serde_bytes.workspace = true
 serde_ipld_dagcbor.workspace = true
 serde_json.workspace = true
+libp2p.workspace = true
+iroh-p2p.workspace = true
+asynchronous-codec = { version = "0.6.1", features = ["cbor", "json"] }
+libp2p-identity = "0.1.2"
+tracing.workspace = true
+rand = "0.8.5"
 
 [dev-dependencies]
 codespan-reporting = "0.11.1"
@@ -22,6 +30,7 @@ lalrpop-util = { version = "0.19.8", features = ["lexer"] }
 pretty = "0.11.3"
 regex = "1"
 rusqlite = "0.29.0"
+serde_cbor = "0.11.2"
 
 
 [build-dependencies]

--- a/recon/Cargo.toml
+++ b/recon/Cargo.toml
@@ -19,18 +19,22 @@ serde_json.workspace = true
 libp2p.workspace = true
 iroh-p2p.workspace = true
 asynchronous-codec = { version = "0.6.1", features = ["cbor", "json"] }
-libp2p-identity = "0.1.2"
+libp2p-identity = { version = "0.1.2", features = ["peerid"] }
 tracing.workspace = true
 rand = "0.8.5"
 
 [dev-dependencies]
+async-std = "1.12.0"
 codespan-reporting = "0.11.1"
 expect-test = "1.4.1"
 lalrpop-util = { version = "0.19.8", features = ["lexer"] }
+libp2p-swarm-test = "0.1.0"
 pretty = "0.11.3"
+quickcheck = "1.0.3"
 regex = "1"
 rusqlite = "0.29.0"
 serde_cbor = "0.11.2"
+tracing-test.workspace = true
 
 
 [build-dependencies]

--- a/recon/src/ahash.rs
+++ b/recon/src/ahash.rs
@@ -54,29 +54,41 @@ impl<'de> Visitor<'de> for ByteVisitor {
     where
         E: de::Error,
     {
-        Ok(AHash::from_bytes(
-            v.try_into()
-                .map_err(|_| ByteVisitor::length_error(v.len()))?,
-        ))
+        if v.is_empty() {
+            Ok(AHash::default())
+        } else {
+            Ok(AHash::from_bytes(
+                v.try_into()
+                    .map_err(|_| ByteVisitor::length_error(v.len()))?,
+            ))
+        }
     }
     fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
     where
         E: de::Error,
     {
-        Ok(AHash::from_bytes(
-            v.as_slice()
-                .try_into()
-                .map_err(|_| ByteVisitor::length_error(v.len()))?,
-        ))
+        if v.is_empty() {
+            Ok(AHash::default())
+        } else {
+            Ok(AHash::from_bytes(
+                v.as_slice()
+                    .try_into()
+                    .map_err(|_| ByteVisitor::length_error(v.len()))?,
+            ))
+        }
     }
     fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
     where
         E: de::Error,
     {
-        Ok(AHash::from_bytes(
-            v.try_into()
-                .map_err(|_| ByteVisitor::length_error(v.len()))?,
-        ))
+        if v.is_empty() {
+            Ok(AHash::default())
+        } else {
+            Ok(AHash::from_bytes(
+                v.try_into()
+                    .map_err(|_| ByteVisitor::length_error(v.len()))?,
+            ))
+        }
     }
     fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
     where
@@ -89,11 +101,15 @@ impl<'de> Visitor<'de> for ByteVisitor {
                 return Err(ByteVisitor::length_error(seq.size_hint().unwrap_or(1) + 32));
             }
         }
-        Ok(AHash::from_bytes(
-            v.as_slice()
-                .try_into()
-                .map_err(|_| ByteVisitor::length_error(v.len()))?,
-        ))
+        if v.is_empty() {
+            Ok(AHash::default())
+        } else {
+            Ok(AHash::from_bytes(
+                v.as_slice()
+                    .try_into()
+                    .map_err(|_| ByteVisitor::length_error(v.len()))?,
+            ))
+        }
     }
 }
 impl<'de> Deserialize<'de> for AHash {

--- a/recon/src/lib.rs
+++ b/recon/src/lib.rs
@@ -1,5 +1,5 @@
 //! Recon is a network protocol for set reconciliation
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 pub use crate::recon::{Hash, Message, Recon};
 pub use ahash::AHash;
@@ -7,6 +7,7 @@ pub use ahash::AHash;
 pub use recon::tests;
 
 mod ahash;
+pub mod libp2p;
 mod recon;
 
 #[cfg(test)]

--- a/recon/src/libp2p.rs
+++ b/recon/src/libp2p.rs
@@ -12,18 +12,22 @@
 
 mod handler;
 mod protocol;
+#[cfg(test)]
+mod tests;
 
-use libp2p::swarm::{ConnectionId, NetworkBehaviour, NotifyHandler, ToSwarm};
+use libp2p::{
+    core::ConnectedPoint,
+    swarm::{ConnectionId, NetworkBehaviour, NotifyHandler, ToSwarm},
+};
 use libp2p_identity::PeerId;
-use rand::{self, distributions::Alphanumeric, Rng};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, VecDeque},
     sync::{Arc, Mutex},
     task::Poll,
     time::{Duration, Instant},
 };
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::{
     libp2p::handler::{FromBehaviour, FromHandler, Handler},
@@ -45,9 +49,6 @@ pub trait Recon {
     fn process_message(&mut self, msg: &Message<Self::Hash>) -> Response<Self::Hash>;
     /// Insert a new key into the key space.
     fn insert_key(&mut self, key: &str);
-    /// Reports the number of keys.
-    /// TODO: Remove this as it was only needed for the demo logic.
-    fn num_keys(&self) -> usize;
 }
 
 // Implement the  Recon trait using crate::recon::Recon
@@ -74,11 +75,24 @@ impl Recon for Arc<Mutex<crate::recon::Recon>> {
             .expect("should be able to acquire lock")
             .process_message(msg)
     }
+}
 
-    fn num_keys(&self) -> usize {
-        self.lock()
-            .expect("should be able to acquire lock")
-            .num_keys()
+/// Config specifies the configurable properties of the Behaviour.
+#[derive(Clone)]
+pub struct Config {
+    /// Start a new sync once the duration has past in the failed or synchronized state.
+    /// Defaults to 1 second.
+    pub per_peer_sync_timeout: Duration,
+    /// Duration to keep the connection alive, even when not inuse.
+    pub idle_keep_alive: Duration,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            per_peer_sync_timeout: Duration::from_millis(1000),
+            idle_keep_alive: Duration::from_millis(1000),
+        }
     }
 }
 
@@ -89,31 +103,46 @@ impl Recon for Arc<Mutex<crate::recon::Recon>> {
 /// the application.
 pub struct Behaviour<R> {
     recon: R,
+    config: Config,
     peers: BTreeMap<PeerId, PeerInfo>,
+    swarm_events_queue: VecDeque<Event>,
 }
 
-/// Information about a specific peer and its sync status.
+/// Information about a remote peer and its sync status.
+#[derive(Clone, Debug)]
 struct PeerInfo {
     status: PeerStatus,
     connection_id: ConnectionId,
     last_sync: Option<Instant>,
+    dialer: bool,
 }
 
-#[derive(PartialEq)]
-enum PeerStatus {
-    Idle,
+/// Status of any synchronization operation with a remote peer.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum PeerStatus {
+    /// Local peer has synchronized with the remote peer at one point.
+    /// There is no ongoing sync operation with the remote peer.
+    Synchronized,
+    /// Local peer has started to synchronize with the remote peer.
     Started,
+    /// The last attempt to synchronize with the remote peer resulted in an error.
+    Failed,
+    /// Local peer has stopped synchronizing with the remote peer and will not attempt to
+    /// synchronize again.
+    Stopped,
 }
 
 impl<R> Behaviour<R> {
     /// Create a new Behavior with the provided Recon implementation.
-    pub fn new(recon: R) -> Self
+    pub fn new(recon: R, config: Config) -> Self
     where
         R: Recon,
     {
         Self {
             recon,
+            config,
             peers: BTreeMap::new(),
+            swarm_events_queue: VecDeque::new(),
         }
     }
 }
@@ -126,12 +155,18 @@ impl<R: Recon + Clone + Send + 'static> NetworkBehaviour for Behaviour<R> {
     fn on_swarm_event(&mut self, event: libp2p::swarm::FromSwarm<Self::ConnectionHandler>) {
         match event {
             libp2p::swarm::FromSwarm::ConnectionEstablished(info) => {
+                let status = PeerStatus::Started;
+                self.swarm_events_queue.push_front(Event::PeerEvent {
+                    remote_peer_id: info.peer_id,
+                    status,
+                });
                 self.peers.insert(
                     info.peer_id,
                     PeerInfo {
-                        status: PeerStatus::Idle,
+                        status,
                         connection_id: info.connection_id,
                         last_sync: None,
+                        dialer: matches!(info.endpoint, ConnectedPoint::Dialer { .. }),
                     },
                 );
             }
@@ -158,11 +193,46 @@ impl<R: Recon + Clone + Send + 'static> NetworkBehaviour for Behaviour<R> {
         event: libp2p::swarm::THandlerOutEvent<Self>,
     ) {
         match event {
+            // The peer has started to synchronize with us.
+            FromHandler::Started => self.peers.entry(peer_id).and_modify(|info| {
+                if info.status != PeerStatus::Started {
+                    info.status = PeerStatus::Started;
+                    self.swarm_events_queue.push_front(Event::PeerEvent {
+                        remote_peer_id: peer_id,
+                        status: info.status,
+                    })
+                }
+            }),
+            // The peer has stopped synchronization and will never be able to resume.
+            FromHandler::Stopped => self.peers.entry(peer_id).and_modify(|info| {
+                info.status = PeerStatus::Stopped;
+                self.swarm_events_queue.push_front(Event::PeerEvent {
+                    remote_peer_id: peer_id,
+                    status: info.status,
+                })
+            }),
+
             // The peer has synchronized with us, mark the time and record that the peer conneciton
             // is now idle.
-            FromHandler::PeerSynchronized => self.peers.entry(peer_id).and_modify(|info| {
+            FromHandler::Succeeded => self.peers.entry(peer_id).and_modify(|info| {
                 info.last_sync = Some(Instant::now());
-                info.status = PeerStatus::Idle;
+                info.status = PeerStatus::Synchronized;
+                self.swarm_events_queue.push_front(Event::PeerEvent {
+                    remote_peer_id: peer_id,
+                    status: info.status,
+                })
+            }),
+
+            // The peer has failed to synchronized with us, mark the time and record that the peer conneciton
+            // is now failed.
+            FromHandler::Failed(error) => self.peers.entry(peer_id).and_modify(|info| {
+                warn!(%peer_id, %error, "synchronization failed with peer");
+                info.last_sync = Some(Instant::now());
+                info.status = PeerStatus::Failed;
+                self.swarm_events_queue.push_front(Event::PeerEvent {
+                    remote_peer_id: peer_id,
+                    status: info.status,
+                })
             }),
         };
     }
@@ -173,66 +243,90 @@ impl<R: Recon + Clone + Send + 'static> NetworkBehaviour for Behaviour<R> {
         _params: &mut impl libp2p::swarm::PollParameters,
     ) -> std::task::Poll<libp2p::swarm::ToSwarm<Self::OutEvent, libp2p::swarm::THandlerInEvent<Self>>>
     {
+        // Handle queue of swarm events.
+        if let Some(event) = self.swarm_events_queue.pop_back() {
+            debug!(?event, "swarm event");
+            return Poll::Ready(ToSwarm::GenerateEvent(event));
+        }
         // Check each peer and start synchronization as needed.
         for (peer_id, info) in &mut self.peers {
-            match info.status {
-                PeerStatus::Idle => {
-                    let should_sync = if let Some(last_sync) = &info.last_sync {
-                        last_sync.elapsed() > Duration::from_millis(5000)
-                    } else {
-                        true
-                    };
-                    if should_sync {
-                        info.status = PeerStatus::Started;
-                        return Poll::Ready(ToSwarm::NotifyHandler {
-                            peer_id: *peer_id,
-                            handler: NotifyHandler::One(info.connection_id),
-                            event: FromBehaviour::StartSync,
-                        });
+            debug!(%peer_id, ?info, "polling peer state");
+            // Expected the initial dialer to initiate a new synchronization.
+            if info.dialer {
+                match info.status {
+                    PeerStatus::Failed | PeerStatus::Synchronized => {
+                        let should_sync = if let Some(last_sync) = &info.last_sync {
+                            last_sync.elapsed() > self.config.per_peer_sync_timeout
+                        } else {
+                            false
+                        };
+                        if should_sync {
+                            info.status = PeerStatus::Started;
+                            self.swarm_events_queue.push_front(Event::PeerEvent {
+                                remote_peer_id: *peer_id,
+                                status: info.status,
+                            });
+                            return Poll::Ready(ToSwarm::NotifyHandler {
+                                peer_id: *peer_id,
+                                handler: NotifyHandler::One(info.connection_id),
+                                event: FromBehaviour::StartSync,
+                            });
+                        }
                     }
+                    PeerStatus::Started | PeerStatus::Stopped => {}
                 }
-                PeerStatus::Started => {}
             }
-        }
-        // TODO remove this demo code
-        // Randomly insert a new key into the Recon key space.
-        if rand::thread_rng().gen::<f64>() > 0.9 {
-            let s: String = rand::thread_rng()
-                .sample_iter(&Alphanumeric)
-                .take(12)
-                .map(char::from)
-                .collect();
-            self.recon.insert_key(&s);
-            debug!("added new key {s}, total keys {}", self.recon.num_keys());
         }
         Poll::Pending
     }
 
     fn handle_established_inbound_connection(
         &mut self,
-        _connection_id: libp2p::swarm::ConnectionId,
+        connection_id: libp2p::swarm::ConnectionId,
         peer: PeerId,
         _local_addr: &libp2p::Multiaddr,
         _remote_addr: &libp2p::Multiaddr,
     ) -> std::result::Result<libp2p::swarm::THandler<Self>, libp2p::swarm::ConnectionDenied> {
-        debug!(%peer, "handle_established_inbound_connection");
-        Ok(Handler::new(self.recon.clone()))
+        debug!(%peer, ?connection_id, "handle_established_inbound_connection");
+        Ok(Handler::new(
+            peer,
+            connection_id,
+            handler::State::WaitingInbound,
+            self.config.idle_keep_alive,
+            self.recon.clone(),
+        ))
     }
 
     fn handle_established_outbound_connection(
         &mut self,
-        _connection_id: libp2p::swarm::ConnectionId,
+        connection_id: libp2p::swarm::ConnectionId,
         peer: PeerId,
         _addr: &libp2p::Multiaddr,
         _role_override: libp2p::core::Endpoint,
     ) -> std::result::Result<libp2p::swarm::THandler<Self>, libp2p::swarm::ConnectionDenied> {
-        debug!(%peer, "handle_established_outbound_connection");
-        Ok(Handler::new(self.recon.clone()))
+        debug!(%peer, ?connection_id, "handle_established_outbound_connection");
+        Ok(Handler::new(
+            peer,
+            connection_id,
+            handler::State::RequestOutbound,
+            self.config.idle_keep_alive,
+            self.recon.clone(),
+        ))
     }
 }
 
 /// Events that the Behaviour can emit to the rest of the application.
-pub struct Event;
+#[derive(Debug)]
+pub enum Event {
+    /// Event indicating we have synchronized with the specific peer.
+    PeerEvent {
+        /// Id of remote peer
+        remote_peer_id: PeerId,
+
+        /// New status of the peer
+        status: PeerStatus,
+    },
+}
 
 // Implement the converstion from Event to an iroh_p2p::Event.
 impl<R: Recon + Clone + Send + 'static> From<Event> for iroh_p2p::behaviour::Event<Behaviour<R>> {

--- a/recon/src/libp2p.rs
+++ b/recon/src/libp2p.rs
@@ -1,0 +1,232 @@
+//! Implementation of Recon over libp2p
+//!
+//! There are various types within this module and its children.
+//!
+//! Behaviour - Responsible for coordiating the many concurrent Recon syncs
+//! handler::Handler - Manages performing a Recon sync with a single peer
+//! Recon - Manages the key space
+//!
+//! The Behaviour and Handler communicate via message passing. The Behaviour can instruct
+//! the Handler to start a sync and the Handler reports to the behaviour once it has
+//! completed a sync.
+
+mod handler;
+mod protocol;
+
+use libp2p::swarm::{ConnectionId, NetworkBehaviour, NotifyHandler, ToSwarm};
+use libp2p_identity::PeerId;
+use rand::{self, distributions::Alphanumeric, Rng};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+    task::Poll,
+    time::{Duration, Instant},
+};
+use tracing::debug;
+
+use crate::{
+    libp2p::handler::{FromBehaviour, FromHandler, Handler},
+    recon::Response,
+    AHash, Hash, Message,
+};
+
+/// Name of the Recon protocol
+pub const PROTOCOL_NAME: &[u8] = b"/ceramic/recon/0.1.0";
+
+/// Defines the Recon API.
+pub trait Recon {
+    /// The specific Hash function to use.
+    type Hash: Hash + std::fmt::Debug + Serialize + for<'de> Deserialize<'de> + Send + 'static;
+    /// Construct a message to send as the first message.
+    fn initial_message(&self) -> Message<Self::Hash>;
+    /// Process an incoming message and respond with a message reply.
+    fn process_message(&mut self, msg: &Message<Self::Hash>) -> Response<Self::Hash>;
+    /// Insert a new key into the key space.
+    fn insert_key(&mut self, key: &str);
+}
+
+// Implement the  Recon trait using crate::recon::Recon
+//
+// NOTE: We use a std::sync::Mutex because we are not doing any async
+// logic within Recon itself, all async logic exists outside its scope.
+// We should use a tokio::sync::Mutex if we introduce any async logic into Recon.
+impl Recon for Arc<Mutex<crate::recon::Recon>> {
+    type Hash = AHash;
+
+    fn insert_key(&mut self, key: &str) {
+        self.lock()
+            .expect("should be able to acquire lock")
+            .insert(key)
+    }
+    fn initial_message(&self) -> Message<Self::Hash> {
+        self.lock()
+            .expect("should be able to acquire lock")
+            .first_message()
+    }
+
+    fn process_message(&mut self, msg: &Message<Self::Hash>) -> Response<Self::Hash> {
+        self.lock()
+            .expect("should be able to acquire lock")
+            .process_message(msg)
+    }
+}
+
+/// Behaviour of Recon on the peer to peer network.
+///
+/// The Behaviour tracks all peers on the network that speak the Recon protocol.
+/// It is reponsible for starting and stoping syncs with various peers depending on the needs of
+/// the application.
+pub struct Behaviour<R> {
+    recon: R,
+    peers: BTreeMap<PeerId, PeerInfo>,
+}
+
+/// Information about a specific peer and its sync status.
+struct PeerInfo {
+    status: PeerStatus,
+    connection_id: ConnectionId,
+    last_sync: Option<Instant>,
+}
+
+#[derive(PartialEq)]
+enum PeerStatus {
+    Idle,
+    Started,
+}
+
+impl<R> Behaviour<R> {
+    /// Create a new Behavior with the provided Recon implementation.
+    pub fn new(recon: R) -> Self
+    where
+        R: Recon,
+    {
+        Self {
+            recon,
+            peers: BTreeMap::new(),
+        }
+    }
+}
+
+impl<R: Recon + Clone + Send + 'static> NetworkBehaviour for Behaviour<R> {
+    type ConnectionHandler = Handler<R>;
+
+    type OutEvent = Event;
+
+    fn on_swarm_event(&mut self, event: libp2p::swarm::FromSwarm<Self::ConnectionHandler>) {
+        match event {
+            libp2p::swarm::FromSwarm::ConnectionEstablished(info) => {
+                self.peers.insert(
+                    info.peer_id,
+                    PeerInfo {
+                        status: PeerStatus::Idle,
+                        connection_id: info.connection_id,
+                        last_sync: None,
+                    },
+                );
+            }
+            libp2p::swarm::FromSwarm::ConnectionClosed(info) => {
+                self.peers.remove(&info.peer_id);
+            }
+            libp2p::swarm::FromSwarm::AddressChange(_) => {}
+            libp2p::swarm::FromSwarm::DialFailure(_) => {}
+            libp2p::swarm::FromSwarm::ListenFailure(_) => {}
+            libp2p::swarm::FromSwarm::NewListener(_) => {}
+            libp2p::swarm::FromSwarm::NewListenAddr(_) => {}
+            libp2p::swarm::FromSwarm::ExpiredListenAddr(_) => {}
+            libp2p::swarm::FromSwarm::ListenerError(_) => {}
+            libp2p::swarm::FromSwarm::ListenerClosed(_) => {}
+            libp2p::swarm::FromSwarm::NewExternalAddr(_) => {}
+            libp2p::swarm::FromSwarm::ExpiredExternalAddr(_) => {}
+        }
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        peer_id: iroh_p2p::PeerId,
+        _connection_id: libp2p::swarm::ConnectionId,
+        event: libp2p::swarm::THandlerOutEvent<Self>,
+    ) {
+        match event {
+            // The peer has synchronized with us, mark the time and record that the peer conneciton
+            // is now idle.
+            FromHandler::PeerSynchronized => self.peers.entry(peer_id).and_modify(|info| {
+                info.last_sync = Some(Instant::now());
+                info.status = PeerStatus::Idle;
+            }),
+        };
+    }
+
+    fn poll(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+        _params: &mut impl libp2p::swarm::PollParameters,
+    ) -> std::task::Poll<libp2p::swarm::ToSwarm<Self::OutEvent, libp2p::swarm::THandlerInEvent<Self>>>
+    {
+        // Check each peer and start synchronization as needed.
+        for (peer_id, info) in &mut self.peers {
+            match info.status {
+                PeerStatus::Idle => {
+                    let should_sync = if let Some(last_sync) = &info.last_sync {
+                        last_sync.elapsed() > Duration::from_millis(1000)
+                    } else {
+                        true
+                    };
+                    if should_sync {
+                        info.status = PeerStatus::Started;
+                        return Poll::Ready(ToSwarm::NotifyHandler {
+                            peer_id: *peer_id,
+                            handler: NotifyHandler::One(info.connection_id),
+                            event: FromBehaviour::StartSync,
+                        });
+                    }
+                }
+                PeerStatus::Started => {}
+            }
+        }
+        // TODO remove this demo code
+        // Randomly insert a new key into the Recon key space.
+        if rand::thread_rng().gen::<f64>() > 0.9 {
+            debug!("adding new key");
+            let s: String = rand::thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(12)
+                .map(char::from)
+                .collect();
+            self.recon.insert_key(&s);
+        }
+        Poll::Pending
+    }
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        _connection_id: libp2p::swarm::ConnectionId,
+        peer: PeerId,
+        _local_addr: &libp2p::Multiaddr,
+        _remote_addr: &libp2p::Multiaddr,
+    ) -> std::result::Result<libp2p::swarm::THandler<Self>, libp2p::swarm::ConnectionDenied> {
+        debug!(%peer, "handle_established_inbound_connection");
+        Ok(Handler::new(self.recon.clone()))
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        _connection_id: libp2p::swarm::ConnectionId,
+        peer: PeerId,
+        _addr: &libp2p::Multiaddr,
+        _role_override: libp2p::core::Endpoint,
+    ) -> std::result::Result<libp2p::swarm::THandler<Self>, libp2p::swarm::ConnectionDenied> {
+        debug!(%peer, "handle_established_outbound_connection");
+        Ok(Handler::new(self.recon.clone()))
+    }
+}
+
+/// Events that the Behaviour can emit to the rest of the application.
+pub struct Event;
+
+// Implement the converstion from Event to an iroh_p2p::Event.
+impl<R: Recon + Clone + Send + 'static> From<Event> for iroh_p2p::behaviour::Event<Behaviour<R>> {
+    fn from(value: Event) -> Self {
+        Self::Custom(value)
+    }
+}

--- a/recon/src/libp2p/handler.rs
+++ b/recon/src/libp2p/handler.rs
@@ -1,0 +1,267 @@
+//! Implementation of the Recon connection handler
+//!
+//! A handler is created for each connected peer that speaks the Recon protocol.
+//! A handler is responsible for performing Recon synchronization with a peer.
+use std::{
+    task::Poll,
+    time::{Duration, Instant},
+};
+
+use anyhow::Result;
+use libp2p::{
+    core::upgrade::ReadyUpgrade,
+    futures::FutureExt,
+    swarm::{
+        handler::{FullyNegotiatedInbound, FullyNegotiatedOutbound},
+        ConnectionHandler, ConnectionHandlerEvent, KeepAlive, SubstreamProtocol,
+    },
+};
+use tracing::debug;
+
+use crate::libp2p::{protocol, Recon, PROTOCOL_NAME};
+
+pub struct Handler<R> {
+    state: State,
+    recon: R,
+    keep_alive: KeepAlive,
+}
+
+impl<R> Handler<R> {
+    pub fn new(recon: R) -> Self {
+        Self {
+            state: State::default(),
+            recon,
+            keep_alive: KeepAlive::No,
+        }
+    }
+    // Transition the state to a new state.
+    //
+    // See doc comment for State, each row of the transitions table
+    // should map to exactly one call of this transition_state function.
+    fn transition_state(&mut self, state: State) {
+        debug!(
+            previous_state = ?self.state,
+            new_state = ?state,
+            "state transition"
+        );
+        self.state = state;
+        // Update KeepAlive
+        self.keep_alive = match (&self.state, self.keep_alive) {
+            (State::Idle, k @ KeepAlive::Until(_)) => k,
+            (State::Idle, _) => KeepAlive::Until(Instant::now() + Duration::from_secs(2)),
+            (State::RequestOutbound, _)
+            | (State::WaitingOutbound, _)
+            | (State::Outbound(_), _)
+            | (State::Inbound(_), _) => KeepAlive::Yes,
+        };
+    }
+}
+
+type SyncFuture = libp2p::futures::future::BoxFuture<'static, Result<()>>;
+
+/// Current state of the handler.
+///
+/// State Transitions:
+///
+/// | State           | Event                                    | New State       |
+/// | -----           | -----                                    | ---------       |
+/// | Idle            | FromBehaviour::StartSync                 | RequestOutbound |
+/// | Idle            | ConnectionEvent::FullyNegotiatedInbound  | Inbound         |
+/// | RequestOutbound | poll                                     | WaitingOutbound |
+/// | WaitingOutbound | ConnectionEvent::FullyNegotiatedOutbound | Outbound        |
+/// | Outbound        | Poll::Ready (i.e. future completed)      | Idle            |
+/// | Inbound         | Poll::Ready (i.e. future completed)      | Idle            |
+///
+/// No other transitions are possible
+#[derive(Default)]
+enum State {
+    #[default]
+    Idle,
+    RequestOutbound,
+    WaitingOutbound,
+    Outbound(SyncFuture),
+    Inbound(SyncFuture),
+}
+
+impl std::fmt::Debug for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Idle => write!(f, "Idle"),
+            Self::RequestOutbound => write!(f, "RequestOutbound"),
+            Self::WaitingOutbound => write!(f, "WaitingOutbound"),
+            Self::Outbound(_) => f.debug_tuple("Outbound").field(&"_").finish(),
+            Self::Inbound(_) => f.debug_tuple("Inbound").field(&"_").finish(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FromBehaviour {
+    StartSync,
+}
+#[derive(Debug)]
+pub enum FromHandler {
+    PeerSynchronized,
+}
+
+#[derive(Debug)]
+pub enum Failure {
+    Timeout,
+    Unsupported,
+    Other {
+        error: Box<dyn std::error::Error + Send + 'static>,
+    },
+}
+
+impl std::fmt::Display for Failure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Failure::Timeout => f.write_str("Ping timeout"),
+            Failure::Other { error } => write!(f, "Ping error: {error}"),
+            Failure::Unsupported => write!(f, "Ping protocol not supported"),
+        }
+    }
+}
+
+impl std::error::Error for Failure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Failure::Timeout => None,
+            Failure::Unsupported => None,
+            Failure::Other { error } => Some(&**error),
+        }
+    }
+}
+
+impl<R: Recon + Clone + Send + 'static> ConnectionHandler for Handler<R> {
+    type InEvent = FromBehaviour;
+    type OutEvent = FromHandler;
+    type Error = Failure;
+    type InboundProtocol = ReadyUpgrade<&'static [u8]>;
+    type OutboundProtocol = ReadyUpgrade<&'static [u8]>;
+    type OutboundOpenInfo = ();
+    type InboundOpenInfo = ();
+
+    fn listen_protocol(
+        &self,
+    ) -> libp2p::swarm::SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
+        SubstreamProtocol::new(ReadyUpgrade::new(PROTOCOL_NAME), ())
+    }
+
+    fn connection_keep_alive(&self) -> KeepAlive {
+        self.keep_alive
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<
+        ConnectionHandlerEvent<
+            Self::OutboundProtocol,
+            Self::OutboundOpenInfo,
+            Self::OutEvent,
+            Self::Error,
+        >,
+    > {
+        match &mut self.state {
+            State::Idle => {}
+            State::RequestOutbound => {
+                self.transition_state(State::WaitingOutbound);
+                // Start outbound connection
+                let protocol = SubstreamProtocol::new(ReadyUpgrade::new(PROTOCOL_NAME), ());
+                return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest { protocol });
+            }
+            State::WaitingOutbound => {}
+            State::Outbound(outbound) => {
+                if let Poll::Ready(result) = outbound.poll_unpin(cx) {
+                    self.transition_state(State::Idle);
+                    match result {
+                        Ok(_) => {
+                            return Poll::Ready(ConnectionHandlerEvent::Custom(
+                                FromHandler::PeerSynchronized,
+                            ))
+                        }
+                        Err(e) => {
+                            // TODO handle error
+                            eprintln!("{e:?}")
+                        }
+                    }
+                }
+            }
+            State::Inbound(inbound) => {
+                if let Poll::Ready(result) = inbound.poll_unpin(cx) {
+                    self.transition_state(State::Idle);
+                    match result {
+                        Ok(_) => {
+                            return Poll::Ready(ConnectionHandlerEvent::Custom(
+                                FromHandler::PeerSynchronized,
+                            ))
+                        }
+                        Err(e) => {
+                            // TODO handle error
+                            eprintln!("{e:?}")
+                        }
+                    }
+                }
+            }
+        };
+
+        Poll::Pending
+    }
+
+    fn on_behaviour_event(&mut self, event: Self::InEvent) {
+        match event {
+            FromBehaviour::StartSync => {
+                debug!("start sync from behavior");
+                match self.state {
+                    State::Idle => self.transition_state(State::RequestOutbound),
+                    State::RequestOutbound
+                    | State::WaitingOutbound
+                    | State::Outbound(_)
+                    | State::Inbound(_) => {}
+                }
+            }
+        }
+    }
+
+    fn on_connection_event(
+        &mut self,
+        event: libp2p::swarm::handler::ConnectionEvent<
+            Self::InboundProtocol,
+            Self::OutboundProtocol,
+            Self::InboundOpenInfo,
+            Self::OutboundOpenInfo,
+        >,
+    ) {
+        match event {
+            libp2p::swarm::handler::ConnectionEvent::FullyNegotiatedInbound(
+                FullyNegotiatedInbound {
+                    protocol: stream, ..
+                },
+            ) => match self.state {
+                State::Idle => self.transition_state(State::Inbound(
+                    protocol::synchronize(self.recon.clone(), stream, false).boxed(),
+                )),
+                // Ignore inbound connection when we are not expecting it
+                State::RequestOutbound
+                | State::WaitingOutbound
+                | State::Outbound(_)
+                | State::Inbound(_) => {}
+            },
+            libp2p::swarm::handler::ConnectionEvent::FullyNegotiatedOutbound(
+                FullyNegotiatedOutbound {
+                    protocol: stream, ..
+                },
+            ) => match self.state {
+                State::WaitingOutbound => self.transition_state(State::Outbound(
+                    protocol::synchronize(self.recon.clone(), stream, true).boxed(),
+                )),
+                // Ignore outbound connection when we are not expecting it
+                State::Idle | State::RequestOutbound | State::Outbound(_) | State::Inbound(_) => {}
+            },
+            libp2p::swarm::handler::ConnectionEvent::AddressChange(_) => {}
+            libp2p::swarm::handler::ConnectionEvent::DialUpgradeError(_) => {}
+            libp2p::swarm::handler::ConnectionEvent::ListenUpgradeError(_) => {}
+        }
+    }
+}

--- a/recon/src/libp2p/handler.rs
+++ b/recon/src/libp2p/handler.rs
@@ -3,6 +3,7 @@
 //! A handler is created for each connected peer that speaks the Recon protocol.
 //! A handler is responsible for performing Recon synchronization with a peer.
 use std::{
+    collections::VecDeque,
     task::Poll,
     time::{Duration, Instant},
 };
@@ -13,25 +14,40 @@ use libp2p::{
     futures::FutureExt,
     swarm::{
         handler::{FullyNegotiatedInbound, FullyNegotiatedOutbound},
-        ConnectionHandler, ConnectionHandlerEvent, KeepAlive, SubstreamProtocol,
+        ConnectionHandler, ConnectionHandlerEvent, ConnectionId, KeepAlive, SubstreamProtocol,
     },
 };
+use libp2p_identity::PeerId;
 use tracing::debug;
 
 use crate::libp2p::{protocol, Recon, PROTOCOL_NAME};
 
 pub struct Handler<R> {
-    state: State,
+    remote_peer_id: PeerId,
+    connection_id: ConnectionId,
     recon: R,
+    state: State,
+    keep_alive_duration: Duration,
     keep_alive: KeepAlive,
+    behavior_events_queue: VecDeque<FromHandler>,
 }
 
 impl<R> Handler<R> {
-    pub fn new(recon: R) -> Self {
+    pub fn new(
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+        state: State,
+        keep_alive_duration: Duration,
+        recon: R,
+    ) -> Self {
         Self {
-            state: State::default(),
+            remote_peer_id: peer_id,
+            connection_id,
             recon,
-            keep_alive: KeepAlive::No,
+            state,
+            keep_alive_duration,
+            keep_alive: KeepAlive::Yes,
+            behavior_events_queue: VecDeque::new(),
         }
     }
     // Transition the state to a new state.
@@ -40,6 +56,8 @@ impl<R> Handler<R> {
     // should map to exactly one call of this transition_state function.
     fn transition_state(&mut self, state: State) {
         debug!(
+            %self.remote_peer_id,
+            ?self.connection_id,
             previous_state = ?self.state,
             new_state = ?state,
             "state transition"
@@ -48,8 +66,9 @@ impl<R> Handler<R> {
         // Update KeepAlive
         self.keep_alive = match (&self.state, self.keep_alive) {
             (State::Idle, k @ KeepAlive::Until(_)) => k,
-            (State::Idle, _) => KeepAlive::Until(Instant::now() + Duration::from_secs(2)),
+            (State::Idle, _) => KeepAlive::Until(Instant::now() + self.keep_alive_duration),
             (State::RequestOutbound, _)
+            | (State::WaitingInbound, _)
             | (State::WaitingOutbound, _)
             | (State::Outbound(_), _)
             | (State::Inbound(_), _) => KeepAlive::Yes,
@@ -63,20 +82,24 @@ type SyncFuture = libp2p::futures::future::BoxFuture<'static, Result<()>>;
 ///
 /// State Transitions:
 ///
-/// | State           | Event                                    | New State       |
-/// | -----           | -----                                    | ---------       |
-/// | Idle            | FromBehaviour::StartSync                 | RequestOutbound |
-/// | Idle            | ConnectionEvent::FullyNegotiatedInbound  | Inbound         |
-/// | RequestOutbound | poll                                     | WaitingOutbound |
-/// | WaitingOutbound | ConnectionEvent::FullyNegotiatedOutbound | Outbound        |
-/// | Outbound        | Poll::Ready (i.e. future completed)      | Idle            |
-/// | Inbound         | Poll::Ready (i.e. future completed)      | Idle            |
+/// | State            | Event                                    | New State       |
+/// | -----            | -----                                    | ---------       |
+/// | Idle             | FromBehaviour::StartSync                 | RequestOutbound |
+/// | Idle             | ConnectionEvent::FullyNegotiatedInbound  | Inbound         |
+/// | WaitingInbound*  | ConnectionEvent::FullyNegotiatedInbound  | Inbound         |
+/// | RequestOutbound* | poll                                     | WaitingOutbound |
+/// | WaitingOutbound  | ConnectionEvent::FullyNegotiatedOutbound | Outbound        |
+/// | WaitingOutbound  | ConnectionEvent::DialUpgradeError        | Idle            |
+/// | WaitingInbound   | ConnectionEvent::ListenUpgradeError      | Idle            |
+/// | Outbound         | Poll::Ready (i.e. future completed)      | Idle            |
+/// | Inbound          | Poll::Ready (i.e. future completed)      | Idle            |
 ///
-/// No other transitions are possible
-#[derive(Default)]
-enum State {
-    #[default]
+/// No other transitions are possible.
+///
+/// * Starting states
+pub enum State {
     Idle,
+    WaitingInbound,
     RequestOutbound,
     WaitingOutbound,
     Outbound(SyncFuture),
@@ -88,6 +111,7 @@ impl std::fmt::Debug for State {
         match self {
             Self::Idle => write!(f, "Idle"),
             Self::RequestOutbound => write!(f, "RequestOutbound"),
+            Self::WaitingInbound => write!(f, "WaitingInbound"),
             Self::WaitingOutbound => write!(f, "WaitingOutbound"),
             Self::Outbound(_) => f.debug_tuple("Outbound").field(&"_").finish(),
             Self::Inbound(_) => f.debug_tuple("Inbound").field(&"_").finish(),
@@ -101,35 +125,26 @@ pub enum FromBehaviour {
 }
 #[derive(Debug)]
 pub enum FromHandler {
-    PeerSynchronized,
+    Started,
+    Succeeded,
+    Stopped,
+    Failed(anyhow::Error),
 }
 
 #[derive(Debug)]
-pub enum Failure {
-    Timeout,
-    Unsupported,
-    Other {
-        error: Box<dyn std::error::Error + Send + 'static>,
-    },
+pub struct Failure {
+    error: Box<dyn std::error::Error + Send + 'static>,
 }
 
 impl std::fmt::Display for Failure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Failure::Timeout => f.write_str("Ping timeout"),
-            Failure::Other { error } => write!(f, "Ping error: {error}"),
-            Failure::Unsupported => write!(f, "Ping protocol not supported"),
-        }
+        write!(f, "Error: {}", self.error)
     }
 }
 
 impl std::error::Error for Failure {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Failure::Timeout => None,
-            Failure::Unsupported => None,
-            Failure::Other { error } => Some(&**error),
-        }
+        Some(&*self.error)
     }
 }
 
@@ -149,6 +164,7 @@ impl<R: Recon + Clone + Send + 'static> ConnectionHandler for Handler<R> {
     }
 
     fn connection_keep_alive(&self) -> KeepAlive {
+        debug!(?self.keep_alive, "connection_keep_alive");
         self.keep_alive
     }
 
@@ -163,43 +179,30 @@ impl<R: Recon + Clone + Send + 'static> ConnectionHandler for Handler<R> {
             Self::Error,
         >,
     > {
+        if let Some(event) = self.behavior_events_queue.pop_back() {
+            return Poll::Ready(ConnectionHandlerEvent::Custom(event));
+        }
         match &mut self.state {
-            State::Idle => {}
+            State::Idle | State::WaitingOutbound | State::WaitingInbound => {}
             State::RequestOutbound => {
                 self.transition_state(State::WaitingOutbound);
                 // Start outbound connection
                 let protocol = SubstreamProtocol::new(ReadyUpgrade::new(PROTOCOL_NAME), ());
                 return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest { protocol });
             }
-            State::WaitingOutbound => {}
-            State::Outbound(outbound) => {
-                if let Poll::Ready(result) = outbound.poll_unpin(cx) {
+            State::Outbound(stream) | State::Inbound(stream) => {
+                if let Poll::Ready(result) = stream.poll_unpin(cx) {
                     self.transition_state(State::Idle);
                     match result {
                         Ok(_) => {
                             return Poll::Ready(ConnectionHandlerEvent::Custom(
-                                FromHandler::PeerSynchronized,
+                                FromHandler::Succeeded,
                             ))
                         }
                         Err(e) => {
-                            // TODO handle error
-                            eprintln!("{e:?}")
-                        }
-                    }
-                }
-            }
-            State::Inbound(inbound) => {
-                if let Poll::Ready(result) = inbound.poll_unpin(cx) {
-                    self.transition_state(State::Idle);
-                    match result {
-                        Ok(_) => {
                             return Poll::Ready(ConnectionHandlerEvent::Custom(
-                                FromHandler::PeerSynchronized,
+                                FromHandler::Failed(e),
                             ))
-                        }
-                        Err(e) => {
-                            // TODO handle error
-                            eprintln!("{e:?}")
                         }
                     }
                 }
@@ -212,11 +215,12 @@ impl<R: Recon + Clone + Send + 'static> ConnectionHandler for Handler<R> {
     fn on_behaviour_event(&mut self, event: Self::InEvent) {
         match event {
             FromBehaviour::StartSync => {
-                debug!("start sync from behavior");
+                debug!(%self.remote_peer_id,  ?self.connection_id, "start sync from behavior");
                 match self.state {
                     State::Idle => self.transition_state(State::RequestOutbound),
                     State::RequestOutbound
                     | State::WaitingOutbound
+                    | State::WaitingInbound
                     | State::Outbound(_)
                     | State::Inbound(_) => {}
                 }
@@ -238,30 +242,92 @@ impl<R: Recon + Clone + Send + 'static> ConnectionHandler for Handler<R> {
                 FullyNegotiatedInbound {
                     protocol: stream, ..
                 },
-            ) => match self.state {
-                State::Idle => self.transition_state(State::Inbound(
-                    protocol::synchronize(self.recon.clone(), stream, false).boxed(),
-                )),
-                // Ignore inbound connection when we are not expecting it
-                State::RequestOutbound
-                | State::WaitingOutbound
-                | State::Outbound(_)
-                | State::Inbound(_) => {}
-            },
+            ) => {
+                debug!(%self.remote_peer_id, ?self.connection_id, "on_connection_event::FullyNegotiatedInbound");
+                match self.state {
+                    State::Idle | State::WaitingInbound => {
+                        self.behavior_events_queue.push_front(FromHandler::Started);
+                        self.transition_state(State::Inbound(
+                            protocol::synchronize(
+                                self.remote_peer_id,
+                                self.connection_id,
+                                self.recon.clone(),
+                                stream,
+                                false,
+                            )
+                            .boxed(),
+                        ));
+                    }
+                    // Ignore inbound connection when we are not expecting it
+                    State::RequestOutbound
+                    | State::WaitingOutbound
+                    | State::Inbound(_)
+                    | State::Outbound(_) => {}
+                }
+            }
             libp2p::swarm::handler::ConnectionEvent::FullyNegotiatedOutbound(
                 FullyNegotiatedOutbound {
                     protocol: stream, ..
                 },
-            ) => match self.state {
-                State::WaitingOutbound => self.transition_state(State::Outbound(
-                    protocol::synchronize(self.recon.clone(), stream, true).boxed(),
-                )),
-                // Ignore outbound connection when we are not expecting it
-                State::Idle | State::RequestOutbound | State::Outbound(_) | State::Inbound(_) => {}
-            },
+            ) => {
+                debug!(%self.remote_peer_id, ?self.connection_id, "on_connection_event::FullyNegotiatedOutbound");
+                match self.state {
+                    State::WaitingOutbound => {
+                        self.behavior_events_queue.push_front(FromHandler::Started);
+                        self.transition_state(State::Outbound(
+                            protocol::synchronize(
+                                self.remote_peer_id,
+                                self.connection_id,
+                                self.recon.clone(),
+                                stream,
+                                true,
+                            )
+                            .boxed(),
+                        ));
+                    }
+                    // Ignore outbound connection when we are not expecting it
+                    State::Idle
+                    | State::WaitingInbound
+                    | State::RequestOutbound
+                    | State::Outbound(_)
+                    | State::Inbound(_) => {}
+                }
+            }
             libp2p::swarm::handler::ConnectionEvent::AddressChange(_) => {}
-            libp2p::swarm::handler::ConnectionEvent::DialUpgradeError(_) => {}
-            libp2p::swarm::handler::ConnectionEvent::ListenUpgradeError(_) => {}
+            // We failed to upgrade the inbound connection.
+            libp2p::swarm::handler::ConnectionEvent::ListenUpgradeError(_) => {
+                debug!(%self.remote_peer_id, ?self.connection_id, "on_connection_event::ListenUpgradeError");
+                match self.state {
+                    State::WaitingInbound => {
+                        // We have stopped synchronization and cannot attempt again as we are unable to
+                        // negotiate a protocol.
+                        self.behavior_events_queue.push_front(FromHandler::Stopped);
+                        self.transition_state(State::Idle)
+                    }
+                    State::Idle
+                    | State::WaitingOutbound
+                    | State::RequestOutbound
+                    | State::Outbound(_)
+                    | State::Inbound(_) => {}
+                }
+            }
+            // We failed to upgrade the outbound connection.
+            libp2p::swarm::handler::ConnectionEvent::DialUpgradeError(_) => {
+                debug!(%self.remote_peer_id, ?self.connection_id, "on_connection_event::DialUpgradeError");
+                match self.state {
+                    State::WaitingOutbound => {
+                        // We have stopped synchronization and cannot attempt again as we are unable to
+                        // negotiate a protocol.
+                        self.behavior_events_queue.push_front(FromHandler::Stopped);
+                        self.transition_state(State::Idle)
+                    }
+                    State::Idle
+                    | State::WaitingInbound
+                    | State::RequestOutbound
+                    | State::Outbound(_)
+                    | State::Inbound(_) => {}
+                }
+            }
         }
     }
 }

--- a/recon/src/libp2p/protocol.rs
+++ b/recon/src/libp2p/protocol.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use asynchronous_codec::{CborCodec, Framed};
+use libp2p::futures::{AsyncRead, AsyncWrite, SinkExt};
+use tracing::{debug, trace};
+
+use crate::{libp2p::Recon, Message};
+
+// Perform Recon synchronization with a peer over a stream.
+//
+// When initiate is true, send the initial message instead of waiting for one.
+pub async fn synchronize<S: AsyncRead + AsyncWrite + Unpin, R: Recon>(
+    mut recon: R,
+    stream: S,
+    initiate: bool,
+) -> Result<()> {
+    debug!("start synchronize");
+    let codec = CborCodec::<Message<R::Hash>, Message<R::Hash>>::new();
+    let mut framed = Framed::new(stream, codec);
+
+    if initiate {
+        let msg = recon.initial_message();
+        framed.send(msg).await?;
+    }
+
+    while let Some(request) = libp2p::futures::TryStreamExt::try_next(&mut framed).await? {
+        let response = recon.process_message(&request);
+        trace!(%request, %response, "recon exchange");
+
+        let is_synchronized = response.is_synchronized();
+        framed.send(response.into_message()).await?;
+        if is_synchronized {
+            break;
+        }
+    }
+    framed.close().await?;
+    debug!("finished synchronize");
+    Ok(())
+}

--- a/recon/src/libp2p/protocol.rs
+++ b/recon/src/libp2p/protocol.rs
@@ -33,6 +33,6 @@ pub async fn synchronize<S: AsyncRead + AsyncWrite + Unpin, R: Recon>(
         }
     }
     framed.close().await?;
-    debug!("finished synchronize");
+    debug!("finished synchronize: total keys {}", recon.num_keys());
     Ok(())
 }

--- a/recon/src/libp2p/tests.rs
+++ b/recon/src/libp2p/tests.rs
@@ -1,0 +1,144 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Integration tests for the `Ping` network behaviour.
+
+use libp2p::swarm::{keep_alive, Swarm, SwarmEvent};
+use libp2p_swarm_test::SwarmExt;
+use quickcheck::QuickCheck;
+use std::{
+    num::NonZeroU8,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tracing::debug;
+use tracing_test::traced_test;
+
+use crate::{
+    libp2p::{Behaviour, Config, Event, PeerStatus},
+    Recon,
+};
+
+#[test]
+#[traced_test]
+fn recon_sync() {
+    // Synchronizing Recon should be invariant to the number of times we drive the swarms.
+    // Driving a swarm effectively starts a new sync.
+    fn prop(drive_count: NonZeroU8) {
+        debug!("count: {drive_count}");
+        let config = Config {
+            // Immediately start a new sync once the previous has finished.
+            per_peer_sync_timeout: Duration::from_millis(0),
+            ..Default::default()
+        };
+        let mut swarm1 = Swarm::new_ephemeral(|_| {
+            Behaviour::new(
+                Arc::new(Mutex::new(Recon::from_set(["swarm1".to_string()].into()))),
+                config.clone(),
+            )
+        });
+        let mut swarm2 = Swarm::new_ephemeral(|_| {
+            Behaviour::new(
+                Arc::new(Mutex::new(Recon::from_set(["swarm2".to_string()].into()))),
+                config,
+            )
+        });
+
+        async_std::task::block_on(async {
+            swarm1.listen().await;
+            swarm2.connect(&mut swarm1).await;
+
+            for _ in 0..drive_count.get() {
+                debug!("start drive");
+                let (swarm1_events, swarm2_events) =
+                    match libp2p_swarm_test::drive(&mut swarm1, &mut swarm2).await {
+                        (
+                            [Event::PeerEvent {
+                                remote_peer_id: p1_started,
+                                status: PeerStatus::Started,
+                                ..
+                            }, Event::PeerEvent {
+                                remote_peer_id: p1_synced,
+                                status: PeerStatus::Synchronized,
+                            }],
+                            [Event::PeerEvent {
+                                remote_peer_id: p2_started,
+                                status: PeerStatus::Started,
+                                ..
+                            }, Event::PeerEvent {
+                                remote_peer_id: p2_synced,
+                                status: PeerStatus::Synchronized,
+                            }],
+                        ) => ((p1_started, p1_synced), (p2_started, p2_synced)),
+                        events => panic!("unexpected swarm events {events:?}"),
+                    };
+
+                debug!("drive finished");
+
+                // Assert both events are about the same peer id, per swarm
+                assert_eq!(swarm1_events.0, swarm1_events.1);
+                assert_eq!(swarm2_events.0, swarm2_events.1);
+
+                // Assert that swarms have synchronized with the opposite peers
+                assert_eq!(&swarm1_events.0, swarm2.local_peer_id());
+                assert_eq!(&swarm2_events.0, swarm1.local_peer_id());
+            }
+        });
+    }
+
+    QuickCheck::new().tests(10).quickcheck(prop as fn(_))
+}
+
+#[test]
+#[traced_test]
+fn unsupported_doesnt_fail() {
+    let mut swarm1 = Swarm::new_ephemeral(|_| keep_alive::Behaviour);
+    let mut swarm2 = Swarm::new_ephemeral(|_| {
+        Behaviour::new(
+            Arc::new(Mutex::new(Recon::from_set([].into()))),
+            Config::default(),
+        )
+    });
+
+    let result = async_std::task::block_on(async {
+        swarm1.listen().await;
+        swarm2.connect(&mut swarm1).await;
+        async_std::task::spawn(swarm1.loop_on_next());
+
+        loop {
+            match swarm2.next_swarm_event().await {
+                SwarmEvent::Behaviour(Event::PeerEvent {
+                    status: PeerStatus::Stopped,
+                    ..
+                }) => break Ok(()),
+                SwarmEvent::ConnectionClosed { cause: Some(e), .. } => {
+                    break Err(e);
+                }
+                SwarmEvent::ConnectionClosed { cause: None, .. } => {
+                    break Ok(());
+                }
+                _ => {}
+            }
+        }
+    });
+
+    result
+        .expect("node with recon protocol should not fail connection due to unsupported protocol");
+}

--- a/recon/src/recon/mod.rs
+++ b/recon/src/recon/mod.rs
@@ -78,6 +78,10 @@ impl Recon {
         response
     }
 
+    /// Report the number of keys.
+    pub fn num_keys(&self) -> usize {
+        self.keys.len()
+    }
     /// Generate a response message for a incoming message
     pub fn process_message<H: Hash>(&mut self, received: &Message<H>) -> Response<H> {
         let mut response = Response {
@@ -187,7 +191,7 @@ impl<H: Hash> Display for Message<H> {
             let hash_hex = if h.is_zero() {
                 "0".to_string()
             } else {
-                format!("{}", &h.to_hex()[0..6])
+                h.to_hex()[0..6].to_string()
             };
             write!(f, "{}, {}, ", k, hash_hex)?;
         }
@@ -246,6 +250,7 @@ impl<H: Hash> Message<H> {
         }
     }
 
+    // Process keys within a specific range. Returns true if the ranges were already insync.
     fn process_range(
         &mut self,
         left_fencepost: &str,
@@ -286,7 +291,7 @@ impl<H: Hash> Message<H> {
             // println!("split ({},{}) {}!={}", left_fencepost, right_fencepost, received_hash.to_hex(), calculated_hash.to_hex());
             self.send_split(left_fencepost, right_fencepost, local_keys);
         }
-        return false;
+        false
     }
 
     fn send_split(&mut self, left_fencepost: &str, right_fencepost: &str, local_keys: &Recon) {


### PR DESCRIPTION
Implements Recon protocol over a network using libp2p. 

This PR contains some demo code to show how Recon works. The demo code generates random strings as keys for Recon. Each node then synchronizes those keys. Additionally each node adds a new random key to their set periodically. 

The behaviour currently attempts to sync to all peers for the entire key space and will restart synchronization 1 second after becoming in sync with a peer.

Anything about storing keys on disk is not covered in this PR.


TODO:

- [x] Remove demo code
- [x] Merge https://github.com/3box/beetle/pull/3/commits into main and update Cargo.toml to use main for beetle fork
- [x]  Add tests

