### PR TITLE
feat: add ceramic peer discovery 

### DIFF
--- a/dev.yaml
+++ b/dev.yaml
@@ -1,0 +1,13 @@
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Network
+metadata:
+  name: dev
+spec:
+  replicas: 5
+  cas:
+    image: ceramicnetwork/ceramic-anchor-service:c56be4a3c0bbda012f4b08347e192caf5c405936
+  ceramic:
+    ipfs:
+      kind: rust
+      image: 3box/ceramic-one:dev
+      imagePullPolicy: IfNotPresent

--- a/one/src/main.rs
+++ b/one/src/main.rs
@@ -80,6 +80,13 @@ struct DaemonOpts {
     /// When true traces will be exported
     #[arg(long, default_value_t = false, env = "CERAMIC_ONE_TRACING")]
     tracing: bool,
+    /// Unique key used to find other Ceramic peers via the DHT
+    #[arg(
+        long,
+        default_value = "/ceramic/testnet-clay",
+        env = "CERAMIC_ONE_NETWORK_ID"
+    )]
+    network_id: String,
 }
 
 #[derive(Args, Debug)]
@@ -179,7 +186,7 @@ impl Daemon {
         let ipfs = Ipfs::builder()
             .with_store(dir.join("store"))
             .await?
-            .with_p2p(p2p_config, dir, Some(recon))
+            .with_p2p(p2p_config, dir, Some(recon), &opts.network_id)
             .await?
             .build()
             .await?;

--- a/one/src/network.rs
+++ b/one/src/network.rs
@@ -81,6 +81,7 @@ impl Builder<WithStore> {
         libp2p_config: Libp2pConfig,
         key_store_path: PathBuf,
         recon: Option<R>,
+        ceramic_peers_key: &str,
     ) -> anyhow::Result<Builder<WithP2p>> {
         let addr = Addr::new_mem();
 
@@ -92,7 +93,7 @@ impl Builder<WithStore> {
 
         let kc = Keychain::<DiskStorage>::new(config.key_store_path.clone()).await?;
 
-        let mut p2p = Node::new(config, addr.clone(), kc, recon).await?;
+        let mut p2p = Node::new(config, addr.clone(), kc, recon, ceramic_peers_key).await?;
 
         let task = task::spawn(async move {
             if let Err(err) = p2p.run().await {

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -636,7 +636,6 @@ fn peer_info_from_lookup(l: Lookup) -> LookupResponse {
 
 #[derive(Debug)]
 pub enum ProviderRequestKey {
-    // TODO: potentially change this to Cid, as that is the only key we use for providers
     Dht(Key),
     Bitswap(u64, Cid),
 }


### PR DESCRIPTION
With this change its now possible for Ceramic nodes to discover each
other when they are connected to the same DHT.

This PR depends on the refactor in #55. The refactor moves code from Beetle into this repo. This allows for the p2p `Node` code to be directly modified instead of attempting to expose API from the Node for these specific needs.