### PR TITLE
feat: add interest synchronization and update Recon 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,6 +1406,7 @@ dependencies = [
  "expect-test",
  "hex",
  "int-enum",
+ "libp2p-identity",
  "minicbor",
  "multibase 0.9.1",
  "once_cell",
@@ -7029,6 +7030,7 @@ dependencies = [
  "tracing",
  "tracing-test",
  "unsigned-varint",
+ "void",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ async-stream = "0.3"
 async-trait = "0.1"
 asynchronous-codec = "0.6"
 bytes = "1.1"
+ceramic-api = { path = "./api" }
+ceramic-api-server = { path = "./api-server" }
 ceramic-core = { path = "./core" }
 ceramic-one = { path = "./one" }
 ceramic-p2p = { path = "./p2p" }
-ceramic-api = { path = "./api" }
-ceramic-api-server = { path = "./api-server" }
 cid = { version = "0.9", features = ["serde-codec"] }
 config = "0.13.1"
 criterion = "0.4"
@@ -44,8 +44,8 @@ libp2p = { version = "0.51", default-features = false }                         
 libp2p-identity = { version = "0.1.2", features = ["peerid", "ed25519"] }
 libp2p-tls = { version = "0.1.0", default-features = false }                     # use explicit version of dep to avoid conflict
 lru = "0.10"
-minicbor = { version = "0.19.1", features = ["alloc"] }
-multiaddr = "0.17"                                                                        # use same version as Iroh
+minicbor = { version = "0.19.1", features = ["alloc", "std"] }
+multiaddr = "0.17"                                                               # use same version as Iroh
 multibase = "0.9"
 multihash = "0.17"
 names = { version = "0.14.0", default-features = false }
@@ -75,7 +75,6 @@ unimock = "0.4"
 unsigned-varint = "0.7"
 void = "1.0"
 zeroize = "1.4"
-
 
 # Uncomment these lines to use a local copy of beetle
 #[patch."https://github.com/nathanielc/beetle"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ iroh-util = { git = "https://github.com/3box/beetle", branch = "main" }
 lazy_static = "1.4"
 libipld = "0.15"                                                                 # use same version as Iroh
 libp2p = { version = "0.51", default-features = false }                          # use same version as Iroh
-libp2p-identity = { version = "0.1.2", features = ["ed25519"] }
+libp2p-identity = { version = "0.1.2", features = ["peerid", "ed25519"] }
 libp2p-tls = { version = "0.1.0", default-features = false }                     # use explicit version of dep to avoid conflict
 lru = "0.10"
 minicbor = { version = "0.19.1", features = ["alloc"] }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,14 +1,20 @@
 use anyhow::Result;
 use tracing::info;
 
-use ceramic_core::{EventId, Network};
+use ceramic_core::{EventId, Interest, Network, PeerId};
 
 use crate::server::Recon;
 
 mod server;
 
-pub async fn start(network: Network, addr: String, recon: impl Recon<Key = EventId>) -> Result<()> {
+pub async fn start(
+    peer_id: PeerId,
+    network: Network,
+    addr: String,
+    interest: impl Recon<Key = Interest>,
+    model: impl Recon<Key = EventId>,
+) -> Result<()> {
     info!("starting ceramic api server");
-    server::create(network, &addr, recon).await;
+    server::create(peer_id, network, &addr, interest, model).await;
     Ok(())
 }

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -229,7 +229,7 @@ where
         let interest = Interest::builder()
             .with_sort_key(&sort_key)
             .with_peer_id(&self.peer_id)
-            .with_range(start.as_slice()..stop.as_slice())
+            .with_range((start.as_slice(), stop.as_slice()))
             .with_not_after(0)
             .build();
         self.interest
@@ -393,7 +393,7 @@ mod tests {
                 Interest::builder()
                     .with_sort_key("model")
                     .with_peer_id(&peer_id)
-                    .with_range(start.as_slice()..end.as_slice())
+                    .with_range((start.as_slice(), end.as_slice()))
                     .with_not_after(0)
                     .build(),
             ))
@@ -456,7 +456,7 @@ mod tests {
                 Interest::builder()
                     .with_sort_key("model")
                     .with_peer_id(&peer_id)
-                    .with_range(start.as_slice()..end.as_slice())
+                    .with_range((start.as_slice(), end.as_slice()))
                     .with_not_after(0)
                     .build(),
             ))
@@ -522,7 +522,7 @@ mod tests {
                 Interest::builder()
                     .with_sort_key("model")
                     .with_peer_id(&peer_id)
-                    .with_range(start.as_slice()..end.as_slice())
+                    .with_range((start.as_slice(), end.as_slice()))
                     .with_not_after(0)
                     .build(),
             ))
@@ -588,7 +588,7 @@ mod tests {
                 Interest::builder()
                     .with_sort_key("model")
                     .with_peer_id(&peer_id)
-                    .with_range(start.as_slice()..end.as_slice())
+                    .with_range((start.as_slice(), end.as_slice()))
                     .with_not_after(0)
                     .build(),
             ))

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -102,20 +102,20 @@ where
 }
 
 #[derive(Clone)]
-pub struct Server<C, IR, MR> {
+pub struct Server<C, I, M> {
     peer_id: PeerId,
     network: Network,
-    interest: IR,
-    model: MR,
+    interest: I,
+    model: M,
     marker: PhantomData<C>,
 }
 
-impl<C, IR, MR> Server<C, IR, MR>
+impl<C, I, M> Server<C, I, M>
 where
-    IR: Recon<Key = Interest>,
-    MR: Recon<Key = EventId>,
+    I: Recon<Key = Interest>,
+    M: Recon<Key = EventId>,
 {
-    pub fn new(peer_id: PeerId, network: Network, interest: IR, model: MR) -> Self {
+    pub fn new(peer_id: PeerId, network: Network, interest: I, model: M) -> Self {
         Server {
             peer_id,
             network,
@@ -132,11 +132,11 @@ use std::error::Error;
 use swagger::ApiError;
 
 #[async_trait]
-impl<C, IR, MR> Api<C> for Server<C, IR, MR>
+impl<C, I, M> Api<C> for Server<C, I, M>
 where
     C: Send + Sync,
-    IR: Recon<Key = Interest> + Sync,
-    MR: Recon<Key = EventId> + Sync,
+    I: Recon<Key = Interest> + Sync,
+    M: Recon<Key = EventId> + Sync,
 {
     async fn ceramic_events_post(
         &self,

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use futures::{future, Stream, StreamExt, TryFutureExt, TryStreamExt};
 use hyper::server::conn::Http;
 use hyper::service::Service;
-use recon::{AssociativeHash, Key, Store};
+use recon::{AssociativeHash, InterestProvider, Key, Store};
 use std::{future::Future, ops::Range};
 use std::{marker::PhantomData, ops::RangeBounds};
 use std::{net::SocketAddr, ops::Bound};
@@ -71,11 +71,12 @@ pub trait Recon: Clone + Send + Sync {
     ) -> Vec<Self::Key>;
 }
 
-impl<K, H, S> Recon for Arc<Mutex<recon::Recon<K, H, S>>>
+impl<K, H, S, I> Recon for Arc<Mutex<recon::Recon<K, H, S, I>>>
 where
     K: Key + Send,
     H: AssociativeHash,
     S: Store<Key = K, Hash = H> + Send,
+    I: InterestProvider<Key = K> + Send,
 {
     type Key = K;
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,6 +27,7 @@ unsigned-varint.workspace = true
 minicbor.workspace = true
 
 serde_bytes = "0.11.11"
+libp2p-identity.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/core/src/interest.rs
+++ b/core/src/interest.rs
@@ -1,0 +1,239 @@
+use anyhow::{anyhow, Result};
+use cbor::{Decoder, Encoder};
+use cid::multihash::{Hasher, Sha2_256};
+use multibase::Base;
+use serde::{Deserialize, Serialize};
+use std::{fmt::Display, io::Cursor, ops::Range, str::FromStr};
+
+pub use libp2p_identity::PeerId;
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
+/// Interest declares an interest in a keyspace for a given peer.
+/// cbor([sort_key, peer_id, start_key, stop_key, not after])
+pub struct Interest(#[serde(with = "serde_bytes")] Vec<u8>);
+
+impl Interest {
+    /// Create a builder for constructing EventIds.
+    pub fn builder() -> Builder<Init> {
+        Builder { state: Init }
+    }
+
+    /// Report the sort key
+    pub fn sort_key(&self) -> Result<String> {
+        let mut decoder = Decoder::from_bytes(self.0.as_slice());
+        let sort_key_bytes = decode_bytes(&mut decoder)?;
+        Ok(String::from_utf8(sort_key_bytes)?)
+    }
+
+    /// Report the PeerId value
+    pub fn peer_id(&self) -> Result<PeerId> {
+        let mut decoder = Decoder::from_bytes(self.0.as_slice());
+        let peer_id_bytes = decode_bytes(&mut decoder)?;
+        Ok(PeerId::from_bytes(&peer_id_bytes)?)
+    }
+
+    /// Report the range value
+    pub fn range(&self) -> Result<Range<Vec<u8>>> {
+        let mut decoder = Decoder::from_bytes(self.0.as_slice());
+        // Skip peer_id
+        decoder.items().next();
+        let start = decode_bytes(&mut decoder)?;
+        let end = decode_bytes(&mut decoder)?;
+        Ok(Range { start, end })
+    }
+
+    /// Report the not after value
+    pub fn not_after(&self) -> Result<u64> {
+        let mut decoder = Decoder::from_bytes(self.0.as_slice());
+        // Skip peer_id
+        decoder.items().next();
+        // Skip start
+        decoder.items().next();
+        // Skip end
+        decoder.items().next();
+
+        Ok(decode_u64(&mut decoder)?)
+    }
+
+    /// Return the interest as a slice of bytes.
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+fn decode_bytes<'a>(decoder: &'a mut Decoder<Cursor<Vec<u8>>>) -> Result<Vec<u8>> {
+    if let Some(item) = decoder.items().next() {
+        let item = item?;
+        match item {
+            cbor::Cbor::Bytes(data) => Ok(data.0),
+            item @ _ => Err(anyhow!("expected cbor bytes, found: {:?}", item)),
+        }
+    } else {
+        Err(anyhow!("expected top level cbor value, found nothing"))
+    }
+}
+fn decode_u64<'a>(decoder: &'a mut Decoder<Cursor<Vec<u8>>>) -> Result<u64> {
+    if let Some(item) = decoder.items().next() {
+        let item = item?;
+        match item {
+            cbor::Cbor::Unsigned(data) => Ok(data.into_u64()),
+            item @ _ => Err(anyhow!("expected cbor unsigned integer, found: {:?}", item)),
+        }
+    } else {
+        Err(anyhow!("expected top level cbor value, found nothing"))
+    }
+}
+
+impl Display for Interest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", multibase::encode(Base::Base58Btc, &self.0))
+    }
+}
+impl FromStr for Interest {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let (_, bytes) = multibase::decode(s)?;
+        // TODO validate these bytes are valid Interest bytes
+        Ok(Self(bytes))
+    }
+}
+
+/// Builder provides an ordered API for constructing an EventId
+#[derive(Debug)]
+pub struct Builder<S: BuilderState> {
+    state: S,
+}
+/// The state of the builder
+pub trait BuilderState {}
+
+/// Initial state of the builder.
+#[derive(Debug)]
+pub struct Init;
+impl BuilderState for Init {}
+
+/// Builder with sort key set
+pub struct WithSortKey {
+    encoder: Encoder<Vec<u8>>,
+}
+impl BuilderState for WithSortKey {}
+
+/// Builder with peer id set
+pub struct WithPeerId {
+    encoder: Encoder<Vec<u8>>,
+}
+impl BuilderState for WithPeerId {}
+
+/// Builder with range key set
+pub struct WithRange {
+    encoder: Encoder<Vec<u8>>,
+}
+impl BuilderState for WithRange {}
+
+/// Builder with not after set
+pub struct WithNotAfter {
+    encoder: Encoder<Vec<u8>>,
+}
+impl BuilderState for WithNotAfter {}
+
+impl Builder<Init> {
+    pub fn with_sort_key(self, sort_key: &str) -> Builder<WithSortKey> {
+        let mut hasher = Sha2_256::default();
+        hasher.update(sort_key.as_bytes());
+        // sha256 is 32 bytes safe to unwrap to [u8; 32]
+        let hash: [u8; 32] = hasher.finalize().try_into().unwrap();
+        let mut encoder = Encoder::from_memory();
+        encoder
+            // Encode last 8 bytes of the sort_key hash
+            .encode([&hash[hash.len() - 8..]])
+            .expect("sort_key should cbor encode");
+        Builder {
+            state: WithSortKey { encoder },
+        }
+    }
+}
+impl Builder<WithSortKey> {
+    pub fn with_peer_id(mut self, peer_id: PeerId) -> Builder<WithPeerId> {
+        self.state
+            .encoder
+            .encode([peer_id.to_bytes()])
+            .expect("peer id should cbor encode");
+        Builder {
+            state: WithPeerId {
+                encoder: self.state.encoder,
+            },
+        }
+    }
+}
+impl Builder<WithPeerId> {
+    pub fn with_range(mut self, range: Range<&[u8]>) -> Builder<WithRange> {
+        self.state
+            .encoder
+            .encode([range.start, range.end])
+            .expect("range should cbor encode");
+        Builder {
+            state: WithRange {
+                encoder: self.state.encoder,
+            },
+        }
+    }
+}
+impl Builder<WithRange> {
+    pub fn with_not_after(mut self, not_after: u64) -> Builder<WithNotAfter> {
+        self.state
+            .encoder
+            .encode([not_after])
+            .expect("not after should cbor encode");
+        Builder {
+            state: WithNotAfter {
+                encoder: self.state.encoder,
+            },
+        }
+    }
+}
+
+impl Builder<WithNotAfter> {
+    pub fn build(mut self) -> Interest {
+        Interest(self.state.encoder.as_bytes().to_vec())
+    }
+}
+
+impl From<&[u8]> for Interest {
+    fn from(bytes: &[u8]) -> Self {
+        Self(bytes.to_owned())
+    }
+}
+
+impl From<Vec<u8>> for Interest {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+}
+impl From<&Vec<u8>> for Interest {
+    fn from(bytes: &Vec<u8>) -> Self {
+        Self(bytes.to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use expect_test::expect;
+
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let peer_id = PeerId::from_str("1AZtAkWrrQrsXMQuBEcBget2vGAPbdQ2Wn4bESe9QEVypJ").unwrap();
+        let interest = Interest::builder()
+            .with_sort_key("model")
+            .with_peer_id(peer_id)
+            .with_range(&vec![0, 1, 2]..&vec![0, 1, 9])
+            .with_not_after(0)
+            .build();
+        expect!["zNKny8dER58V97oWgQS2cb7JCuQtpLjgm3qbobm7QU4N6sUHbX5szR9i8T8RdJgvnEHfTG1gL7FJmgwiTvaCDFiNGbWVjKt6aaX2mP3X38mrdtw8sU9SqJjwRQAT"].assert_eq(&interest.to_string());
+
+        assert_eq!(interest, Interest::from_str(&interest.to_string()).unwrap());
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,7 @@ mod interest;
 mod jwk;
 mod jws;
 mod network;
+mod range;
 mod stream_id;
 
 pub use bytes::Bytes;
@@ -15,6 +16,7 @@ pub use interest::{Interest, PeerId};
 pub use jwk::Jwk;
 pub use jws::Jws;
 pub use network::Network;
+pub use range::RangeOpen;
 pub use stream_id::{StreamId, StreamIdType};
 
 pub use cid::Cid;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(missing_docs)]
 mod bytes;
 mod event_id;
+mod interest;
 mod jwk;
 mod jws;
 mod network;
@@ -10,6 +11,7 @@ mod stream_id;
 
 pub use bytes::Bytes;
 pub use event_id::EventId;
+pub use interest::{Interest, PeerId};
 pub use jwk::Jwk;
 pub use jws::Jws;
 pub use network::Network;

--- a/core/src/range.rs
+++ b/core/src/range.rs
@@ -1,0 +1,49 @@
+use std::ops::{Bound, RangeBounds};
+
+/// An open interval from start to end, exclusive on both bounds.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct RangeOpen<T> {
+    /// Exclusive lower bound of the range
+    pub start: T,
+    /// Exclusive upper bound of the range
+    pub end: T,
+}
+
+impl<T> RangeBounds<T> for RangeOpen<T> {
+    fn start_bound(&self) -> Bound<&T> {
+        Bound::Excluded(&self.start)
+    }
+
+    fn end_bound(&self) -> Bound<&T> {
+        Bound::Excluded(&self.end)
+    }
+}
+
+impl<T> From<(T, T)> for RangeOpen<T> {
+    fn from(value: (T, T)) -> Self {
+        Self {
+            start: value.0,
+            end: value.1,
+        }
+    }
+}
+
+impl<T> RangeOpen<T>
+where
+    T: Ord + Clone,
+{
+    /// Construct a new [`RangeOpen`] bounds that represents the intersection of two bounds.
+    /// When there is no overlapping intersection None is returned.
+    pub fn intersect(&self, other: &Self) -> Option<Self> {
+        let start = std::cmp::max(&self.start, &other.start);
+        let end = std::cmp::min(&self.end, &other.end);
+        if start < end {
+            Some(Self {
+                start: start.clone(),
+                end: end.clone(),
+            })
+        } else {
+            None
+        }
+    }
+}

--- a/one/src/network.rs
+++ b/one/src/network.rs
@@ -79,16 +79,16 @@ impl Builder<Init> {
 
 /// Configure the p2p service
 impl Builder<WithStore> {
-    pub async fn with_p2p<IR, MR>(
+    pub async fn with_p2p<I, M>(
         self,
         libp2p_config: Libp2pConfig,
         key_store_path: PathBuf,
-        recons: Option<(IR, MR)>,
+        recons: Option<(I, M)>,
         ceramic_peers_key: &str,
     ) -> anyhow::Result<Builder<WithP2p>>
     where
-        IR: Recon<Key = Interest, Hash = Sha256a>,
-        MR: Recon<Key = EventId, Hash = Sha256a>,
+        I: Recon<Key = Interest, Hash = Sha256a>,
+        M: Recon<Key = EventId, Hash = Sha256a>,
     {
         let addr = Addr::new_mem();
 

--- a/one/src/network.rs
+++ b/one/src/network.rs
@@ -1,14 +1,15 @@
 //! API to create and manage an IPFS service.
 
+use std::{path::PathBuf, sync::Arc};
+
 use anyhow::{Context, Result};
-use ceramic_core::{EventId, Interest};
+use ceramic_core::{EventId, Interest, PeerId};
 use ceramic_kubo_rpc::IpfsService;
 use ceramic_p2p::{Config as P2pConfig, DiskStorage, Keychain, Libp2pConfig, Node};
 use iroh_rpc_client::{P2pClient, StoreClient};
 use iroh_rpc_types::{p2p::P2pAddr, store::StoreAddr, Addr};
 use iroh_store::{Config as StoreConfig, Store};
 use recon::{libp2p::Recon, Sha256a};
-use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
 use tokio::task::{self, JoinHandle};
 use tracing::{error, info};
 
@@ -32,6 +33,7 @@ impl BuilderState for WithStore {}
 
 /// A builder that has been configured with its p2p service.
 pub struct WithP2p {
+    peer_id: PeerId,
     store: Service<StoreAddr>,
     p2p: Service<P2pAddr>,
 }
@@ -99,6 +101,7 @@ impl Builder<WithStore> {
         let kc = Keychain::<DiskStorage>::new(config.key_store_path.clone()).await?;
 
         let mut p2p = Node::new(config, addr.clone(), kc, recons, ceramic_peers_key).await?;
+        let peer_id = *p2p.local_peer_id();
 
         let task = task::spawn(async move {
             if let Err(err) = p2p.run().await {
@@ -108,6 +111,7 @@ impl Builder<WithStore> {
 
         Ok(Builder {
             state: WithP2p {
+                peer_id,
                 store: self.state.store,
                 p2p: Service { addr, task },
             },
@@ -119,6 +123,7 @@ impl Builder<WithStore> {
 impl Builder<WithP2p> {
     pub async fn build(self) -> Result<Ipfs> {
         Ok(Ipfs {
+            peer_id: self.state.peer_id,
             api: Arc::new(IpfsService::new(
                 P2pClient::new(self.state.p2p.addr.clone()).await?,
                 StoreClient::new(self.state.store.addr.clone()).await?,
@@ -131,6 +136,7 @@ impl Builder<WithP2p> {
 
 // Provides Ipfs node implementation
 pub struct Ipfs {
+    peer_id: PeerId,
     api: Arc<IpfsService>,
     p2p: Service<P2pAddr>,
     store: Service<StoreAddr>,
@@ -139,6 +145,9 @@ pub struct Ipfs {
 impl Ipfs {
     pub fn builder() -> Builder<Init> {
         Builder { state: Init {} }
+    }
+    pub fn peer_id(&self) -> PeerId {
+        self.peer_id
     }
     pub fn api(&self) -> Arc<IpfsService> {
         self.api.clone()

--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -39,7 +39,7 @@ pub const AGENT_VERSION: &str = concat!("iroh/", env!("CARGO_PKG_VERSION"));
 /// Libp2p behaviour for the node.
 #[derive(NetworkBehaviour)]
 #[behaviour(out_event = "Event")]
-pub(crate) struct NodeBehaviour<IR, MR> {
+pub(crate) struct NodeBehaviour<I, M> {
     ping: Ping,
     identify: identify::Behaviour,
     pub(crate) bitswap: Toggle<Bitswap<BitswapStore>>,
@@ -52,7 +52,7 @@ pub(crate) struct NodeBehaviour<IR, MR> {
     pub(crate) gossipsub: Toggle<gossipsub::Behaviour>,
     pub(crate) peer_manager: PeerManager,
     limits: connection_limits::Behaviour,
-    recon: Toggle<recon::libp2p::Behaviour<IR, MR>>,
+    recon: Toggle<recon::libp2p::Behaviour<I, M>>,
 }
 
 #[derive(Debug, Clone)]
@@ -88,17 +88,17 @@ impl Store for BitswapStore {
     }
 }
 
-impl<IR, MR> NodeBehaviour<IR, MR>
+impl<I, M> NodeBehaviour<I, M>
 where
-    IR: Recon<Key = Interest, Hash = Sha256a>,
-    MR: Recon<Key = EventId, Hash = Sha256a>,
+    I: Recon<Key = Interest, Hash = Sha256a>,
+    M: Recon<Key = EventId, Hash = Sha256a>,
 {
     pub async fn new(
         local_key: &Keypair,
         config: &Libp2pConfig,
         relay_client: Option<relay::client::Behaviour>,
         rpc_client: Client,
-        recons: Option<(IR, MR)>,
+        recons: Option<(I, M)>,
     ) -> Result<Self> {
         let peer_manager = PeerManager::default();
         let pub_key = local_key.public();

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -1262,18 +1262,19 @@ mod tests {
             + serde::Serialize
             + for<'de> serde::Deserialize<'de>
             + Send
+            + Sync
             + 'static,
     {
         type Key = K;
         type Hash = Sha256a;
 
-        fn initial_message(&self) -> recon::Message<Self::Key, Self::Hash> {
+        fn initial_messages(&self) -> Result<Vec<recon::Message<Self::Key, Self::Hash>>> {
             unreachable!()
         }
 
-        fn process_message(
+        fn process_messages(
             &mut self,
-            _msg: &recon::Message<Self::Key, Self::Hash>,
+            _msg: &[recon::Message<Self::Key, Self::Hash>],
         ) -> Result<recon::Response<Self::Key, Self::Hash>> {
             unreachable!()
         }

--- a/p2p/src/swarm.rs
+++ b/p2p/src/swarm.rs
@@ -106,15 +106,15 @@ async fn build_transport(
     (transport, relay_client)
 }
 
-pub(crate) async fn build_swarm<IR, MR>(
+pub(crate) async fn build_swarm<I, M>(
     config: &Libp2pConfig,
     keypair: &Keypair,
     rpc_client: Client,
-    recons: Option<(IR, MR)>,
-) -> Result<Swarm<NodeBehaviour<IR, MR>>>
+    recons: Option<(I, M)>,
+) -> Result<Swarm<NodeBehaviour<I, M>>>
 where
-    IR: Recon<Key = Interest, Hash = Sha256a>,
-    MR: Recon<Key = EventId, Hash = Sha256a>,
+    I: Recon<Key = Interest, Hash = Sha256a>,
+    M: Recon<Key = EventId, Hash = Sha256a>,
 {
     let peer_id = keypair.public().to_peer_id();
 

--- a/recon/Cargo.toml
+++ b/recon/Cargo.toml
@@ -25,6 +25,7 @@ serde_json.workspace = true
 tracing.workspace = true
 unsigned-varint = "0.7.1"
 ceramic-core.workspace = true
+void.workspace = true
 
 [dev-dependencies]
 async-std = "1.12.0"

--- a/recon/src/lib.rs
+++ b/recon/src/lib.rs
@@ -2,6 +2,8 @@
 #![warn(missing_docs, missing_debug_implementations, clippy::all)]
 
 pub use crate::recon::{btree::BTreeStore, AssociativeHash, Key, Message, Recon, Response, Store};
+#[cfg(test)]
+use recon::tests;
 pub use sha256a::Sha256a;
 
 pub mod libp2p;

--- a/recon/src/lib.rs
+++ b/recon/src/lib.rs
@@ -5,8 +5,6 @@ pub use crate::recon::{
     btree::BTreeStore, AssociativeHash, FullInterests, InterestProvider, Key, Message, Recon,
     Response, Store,
 };
-#[cfg(test)]
-use recon::tests;
 pub use sha256a::Sha256a;
 
 pub mod libp2p;

--- a/recon/src/lib.rs
+++ b/recon/src/lib.rs
@@ -1,7 +1,10 @@
 //! Recon is a network protocol for set reconciliation
 #![warn(missing_docs, missing_debug_implementations, clippy::all)]
 
-pub use crate::recon::{btree::BTreeStore, AssociativeHash, Key, Message, Recon, Response, Store};
+pub use crate::recon::{
+    btree::BTreeStore, AssociativeHash, FullInterests, InterestProvider, Key, Message, Recon,
+    Response, Store,
+};
 #[cfg(test)]
 use recon::tests;
 pub use sha256a::Sha256a;

--- a/recon/src/libp2p.rs
+++ b/recon/src/libp2p.rs
@@ -146,9 +146,9 @@ impl Default for Config {
 /// It is responsible for starting and stopping syncs with various peers depending on the needs of
 /// the application.
 #[derive(Debug)]
-pub struct Behaviour<IR, MR> {
-    interest: IR,
-    model: MR,
+pub struct Behaviour<I, M> {
+    interest: I,
+    model: M,
     config: Config,
     peers: BTreeMap<PeerId, PeerInfo>,
     swarm_events_queue: VecDeque<Event>,
@@ -186,12 +186,12 @@ pub enum PeerStatus {
     Stopped,
 }
 
-impl<IR, MR> Behaviour<IR, MR> {
+impl<I, M> Behaviour<I, M> {
     /// Create a new Behavior with the provided Recon implementation.
-    pub fn new(interest: IR, model: MR, config: Config) -> Self
+    pub fn new(interest: I, model: M, config: Config) -> Self
     where
-        IR: Recon<Key = Interest, Hash = Sha256a>,
-        MR: Recon<Key = EventId, Hash = Sha256a>,
+        I: Recon<Key = Interest, Hash = Sha256a>,
+        M: Recon<Key = EventId, Hash = Sha256a>,
     {
         Self {
             interest,
@@ -203,12 +203,12 @@ impl<IR, MR> Behaviour<IR, MR> {
     }
 }
 
-impl<IR, MR> NetworkBehaviour for Behaviour<IR, MR>
+impl<I, M> NetworkBehaviour for Behaviour<I, M>
 where
-    IR: Recon<Key = Interest, Hash = Sha256a>,
-    MR: Recon<Key = EventId, Hash = Sha256a>,
+    I: Recon<Key = Interest, Hash = Sha256a>,
+    M: Recon<Key = EventId, Hash = Sha256a>,
 {
-    type ConnectionHandler = Handler<IR, MR>;
+    type ConnectionHandler = Handler<I, M>;
 
     type OutEvent = Event;
 

--- a/recon/src/libp2p.rs
+++ b/recon/src/libp2p.rs
@@ -406,10 +406,12 @@ pub enum Event {
 }
 
 #[derive(Debug)]
+
+/// Event about a remote peer
 pub struct PeerEvent {
     /// Id of remote peer
-    remote_peer_id: PeerId,
+    pub remote_peer_id: PeerId,
 
-    /// New status of the peer
-    status: PeerStatus,
+    /// Status of the peer
+    pub status: PeerStatus,
 }

--- a/recon/src/libp2p/handler.rs
+++ b/recon/src/libp2p/handler.rs
@@ -26,29 +26,29 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub struct Handler<IR, MR> {
+pub struct Handler<I, M> {
     remote_peer_id: PeerId,
     connection_id: ConnectionId,
-    interest: IR,
-    model: MR,
+    interest: I,
+    model: M,
     state: State,
     keep_alive_duration: Duration,
     keep_alive: KeepAlive,
     behavior_events_queue: VecDeque<FromHandler>,
 }
 
-impl<IR, MR> Handler<IR, MR>
+impl<I, M> Handler<I, M>
 where
-    IR: Recon<Key = Interest, Hash = Sha256a>,
-    MR: Recon<Key = EventId, Hash = Sha256a>,
+    I: Recon<Key = Interest, Hash = Sha256a>,
+    M: Recon<Key = EventId, Hash = Sha256a>,
 {
     pub fn new(
         peer_id: PeerId,
         connection_id: ConnectionId,
         state: State,
         keep_alive_duration: Duration,
-        interest: IR,
-        model: MR,
+        interest: I,
+        model: M,
     ) -> Self {
         Self {
             remote_peer_id: peer_id,
@@ -165,10 +165,10 @@ impl std::error::Error for Failure {
     }
 }
 
-impl<IR, MR> ConnectionHandler for Handler<IR, MR>
+impl<I, M> ConnectionHandler for Handler<I, M>
 where
-    IR: Recon<Key = Interest, Hash = Sha256a> + Clone + Send + 'static,
-    MR: Recon<Key = EventId, Hash = Sha256a> + Clone + Send + 'static,
+    I: Recon<Key = Interest, Hash = Sha256a> + Clone + Send + 'static,
+    M: Recon<Key = EventId, Hash = Sha256a> + Clone + Send + 'static,
 {
     type InEvent = FromBehaviour;
     type OutEvent = FromHandler;

--- a/recon/src/libp2p/protocol.rs
+++ b/recon/src/libp2p/protocol.rs
@@ -12,7 +12,7 @@ use tracing::{debug, trace};
 
 use crate::{
     libp2p::{stream_set::StreamSet, Recon},
-    AssociativeHash, Key, Message, Store,
+    AssociativeHash, Key, Message,
 };
 
 #[derive(Serialize, Deserialize)]

--- a/recon/src/libp2p/stream_set.rs
+++ b/recon/src/libp2p/stream_set.rs
@@ -1,0 +1,45 @@
+use anyhow::anyhow;
+
+use libp2p::core::upgrade::ProtocolName;
+
+use crate::libp2p::{PROTOCOL_NAME_INTEREST, PROTOCOL_NAME_MODEL};
+
+/// Represents a stream set key
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum StreamSet {
+    /// Stream set of interest ranges
+    Interest,
+    /// Stream set of models
+    Model,
+}
+
+impl StreamSet {
+    /// Report the sort key for this stream set.
+    pub fn sort_key(&self) -> &str {
+        match self {
+            StreamSet::Interest => "interest",
+            StreamSet::Model => "model",
+        }
+    }
+}
+
+impl TryFrom<&str> for StreamSet {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "model" => Ok(StreamSet::Model),
+            "interest" => Ok(StreamSet::Interest),
+            _ => Err(anyhow!("unknown sort_key {}", value)),
+        }
+    }
+}
+
+impl ProtocolName for StreamSet {
+    fn protocol_name(&self) -> &[u8] {
+        match self {
+            StreamSet::Interest => PROTOCOL_NAME_INTEREST,
+            StreamSet::Model => PROTOCOL_NAME_MODEL,
+        }
+    }
+}

--- a/recon/src/libp2p/tests.rs
+++ b/recon/src/libp2p/tests.rs
@@ -41,6 +41,7 @@ use crate::{
 
 type ReconInterest = Recon<Interest, Sha256a, BTreeStore<Interest, Sha256a>>;
 type ReconModel = Recon<EventId, Sha256a, BTreeStore<EventId, Sha256a>>;
+type SwarmTest = Swarm<Behaviour<Arc<Mutex<ReconInterest>>, Arc<Mutex<ReconModel>>>>;
 
 fn random_cid() -> Cid {
     let mut data = [0u8; 64];
@@ -49,18 +50,15 @@ fn random_cid() -> Cid {
     Cid::new_v1(0x12, hash)
 }
 
-fn build_swarm(
-    name: &str,
-    config: Config,
-) -> Swarm<Behaviour<Arc<Mutex<ReconInterest>>, Arc<Mutex<ReconModel>>>> {
+fn build_swarm(name: &str, config: Config) -> SwarmTest {
     Swarm::new_ephemeral(|identity| {
         let peer_id = PeerId::from(identity.public());
         Behaviour::new(
             Arc::new(Mutex::new(ReconInterest::new(BTreeStore::from_set(
                 [Interest::builder()
                     .with_sort_key("model")
-                    .with_peer_id(peer_id)
-                    .with_range(&[]..&[0xFF])
+                    .with_peer_id(&peer_id)
+                    .with_range(&[]..&[0xFF; 1024])
                     .with_not_after(100)
                     .build()]
                 .into(),

--- a/recon/src/libp2p/tests.rs
+++ b/recon/src/libp2p/tests.rs
@@ -62,7 +62,7 @@ fn build_swarm(name: &str, config: Config) -> SwarmTest {
                 [Interest::builder()
                     .with_sort_key("model")
                     .with_peer_id(&peer_id)
-                    .with_range(&[]..&[0xFF; 1])
+                    .with_range((&[][..], &[0xFF; 1][..]))
                     .with_not_after(100)
                     .build()]
                 .into(),

--- a/recon/src/libp2p/upgrade.rs
+++ b/recon/src/libp2p/upgrade.rs
@@ -1,0 +1,56 @@
+use std::vec;
+
+use libp2p::core::UpgradeInfo;
+use libp2p::{core::upgrade::ProtocolName, futures::future, InboundUpgrade, OutboundUpgrade};
+use void::Void;
+
+/// Implementation of [`UpgradeInfo`], [`InboundUpgrade`] and [`OutboundUpgrade`] for a set of protocols that directly yields the substream.
+#[derive(Debug, Clone)]
+pub struct MultiReadyUpgrade<P> {
+    protocol_names: Vec<P>,
+}
+
+impl<P> MultiReadyUpgrade<P> {
+    pub fn new(protocol_names: Vec<P>) -> Self {
+        Self { protocol_names }
+    }
+}
+
+impl<P> UpgradeInfo for MultiReadyUpgrade<P>
+where
+    P: ProtocolName + Clone,
+{
+    type Info = P;
+    type InfoIter = vec::IntoIter<P>;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        self.protocol_names.clone().into_iter()
+    }
+}
+
+impl<C, P> InboundUpgrade<C> for MultiReadyUpgrade<P>
+where
+    P: ProtocolName + Clone,
+{
+    /// Report both the negotiated protocol and the stream.
+    type Output = (P, C);
+    type Error = Void;
+    type Future = future::Ready<Result<Self::Output, Self::Error>>;
+
+    fn upgrade_inbound(self, stream: C, info: Self::Info) -> Self::Future {
+        future::ready(Ok((info, stream)))
+    }
+}
+
+impl<C, P> OutboundUpgrade<C> for MultiReadyUpgrade<P>
+where
+    P: ProtocolName + Clone,
+{
+    type Output = C;
+    type Error = Void;
+    type Future = future::Ready<Result<Self::Output, Self::Error>>;
+
+    fn upgrade_outbound(self, stream: C, _: Self::Info) -> Self::Future {
+        future::ready(Ok(stream))
+    }
+}

--- a/recon/src/recon.rs
+++ b/recon/src/recon.rs
@@ -5,7 +5,7 @@ mod tests;
 use std::fmt::Display;
 
 use anyhow::{bail, Result};
-use ceramic_core::EventId;
+use ceramic_core::{EventId, Interest};
 use serde::{Deserialize, Serialize};
 use tracing::{instrument, trace};
 
@@ -556,6 +556,21 @@ impl Key for EventId {
 
     fn max_value() -> Self {
         // No EventId starts with an 0xFF byte
+        vec![0xFF].into()
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl Key for Interest {
+    fn min_value() -> Self {
+        Vec::new().into()
+    }
+
+    fn max_value() -> Self {
+        // No Interest starts with an 0xFF byte
         vec![0xFF].into()
     }
 

--- a/recon/src/recon.rs
+++ b/recon/src/recon.rs
@@ -89,6 +89,11 @@ where
     pub fn process_messages(&mut self, received: &[Message<K, H>]) -> Result<Response<K, H>> {
         // First we must find the intersection of interests.
         // Then reply with a message per intersection.
+        //
+        // TODO: This is O(n^2) over the number of interests.
+        // We should make this more efficient in the future.
+        // Potentially we could use a variant of https://en.wikipedia.org/wiki/Bounding_volume_hierarchy
+        // to quickly find intersections.
         let mut intersections: Vec<(RangeOpen<K>, BoundedMessage<K, H>)> = Vec::new();
         for range in self.interests.interests()? {
             for msg in received {
@@ -98,7 +103,6 @@ where
                 }
             }
         }
-        debug!(?intersections, "computed intersections");
 
         let mut response = Response {
             is_synchronized: true,
@@ -629,7 +633,7 @@ where
         // TODO: Can we do this without allocating?
         // Some challenges that make this hard currently:
         //  1. The process_messages method iterates over the keys twice
-        //  2. We need to be sure we do not produce too many hashes
+        //  2. We have to keep keys and hashes properly aligned
 
         debug!(?self.keys, "bound keys");
         let mut hashes = self.hashes.iter();

--- a/recon/src/recon/parser.lalrpop
+++ b/recon/src/recon/parser.lalrpop
@@ -1,5 +1,5 @@
 use super::*;
-use ceramic_core::Bytes;
+use ceramic_core::{Bytes,RangeOpen};
 use lalrpop_util::ParseError;
 
 grammar;
@@ -29,8 +29,8 @@ Interests: FixedInterests = {
     }
 };
 
-Interest: (Bytes,Bytes) = {
-    "(" <start:Word> "," <end:Word> ")" => (Bytes::from(start), Bytes::from(end))
+Interest: RangeOpen<Bytes> = {
+    "(" <start:Word> "," <end:Word> ")" => (Bytes::from(start), Bytes::from(end)).into()
 };
 
 Set: Set = {

--- a/recon/src/recon/parser.lalrpop
+++ b/recon/src/recon/parser.lalrpop
@@ -11,11 +11,26 @@ pub Record : Record = {
         iterations,
     },
 };
-Cat: ReconMemoryBytes = {
-    "cat:" <Set> => ReconMemoryBytes::new(BTreeStore::from_set(<>)),
+Cat: ReconMemoryBytes<FixedInterests> = {
+    "cat:" <interests:Interests?> <set:Set> => ReconMemoryBytes::new(BTreeStore::from_set(set), interests.unwrap_or_else(|| FixedInterests::full())),
 };
-Dog: ReconMemoryBytes = {
-    "dog:" <Set> => ReconMemoryBytes::new(BTreeStore::from_set(<>)),
+Dog: ReconMemoryBytes<FixedInterests> = {
+    "dog:" <interests:Interests?> <set:Set> => ReconMemoryBytes::new(BTreeStore::from_set(set), interests.unwrap_or_else(|| FixedInterests::full())),
+};
+
+Interests: FixedInterests = {
+    "<" <first:Interest?> <rest:("," <Interest>)*> ">" => {
+        let mut interests = Vec::new();
+        if let Some(first) = first {
+            interests.push(first);
+        }
+        interests.extend(rest.into_iter());
+        FixedInterests(interests)
+    }
+};
+
+Interest: (Bytes,Bytes) = {
+    "(" <start:Word> "," <end:Word> ")" => (Bytes::from(start), Bytes::from(end))
 };
 
 Set: Set = {
@@ -38,9 +53,9 @@ Word : String = {
 };
 
 Iteration : Iteration = {
-    <dir:Direction> <msg:Message> <set:Set> => Iteration {
+    <dir:Direction> <messages:Messages> <set:Set> => Iteration {
         dir,
-        msg,
+        messages,
         set,
     }
 };
@@ -51,6 +66,16 @@ Direction : Direction = {
     "<-" => Direction::DogToCat,
 };
 
+Messages : Vec<MessageData> = {
+    <first:Message?> <rest:("," <Message>)*> => {
+        let mut messages = Vec::new();
+        if let Some(first) = first {
+            messages.push(first);
+        }
+        messages.extend(rest.into_iter());
+        messages
+    }
+}
 Message : MessageData = {
     "(" <MessageItem?> <("," <MessageItem>)*> ")" =>? (<>).try_into().map_err(|e: &'static str| ParseError::User{
         error: e,
@@ -60,5 +85,7 @@ Message : MessageData = {
 MessageItem : MessageItem = {
     "h(" <SetInner> ")" => MessageItem::Hash(<>),
     "0"                 => MessageItem::Hash(Set::new()),
+    "<" <Word>          => MessageItem::Start(<>),
+    <Word> ">"          => MessageItem::End(<>),
     Word                => MessageItem::Key(<>),
 };

--- a/recon/src/recon/tests.rs
+++ b/recon/src/recon/tests.rs
@@ -3,7 +3,7 @@ lalrpop_util::lalrpop_mod!(
     pub parser, "/recon/parser.rs"
 ); // synthesized by LALRPOP
 
-use ceramic_core::Bytes;
+use ceramic_core::{Bytes, RangeOpen};
 use rusqlite::{Connection, Result};
 use std::collections::BTreeSet;
 use std::fmt::Display;
@@ -109,11 +109,11 @@ pub type ReconBytes = Recon<Bytes, Sha256a, BTreeStore<Bytes, Sha256a>, FullInte
 
 /// Implement InterestProvider for a fixed set of interests.
 #[derive(Debug, PartialEq)]
-pub struct FixedInterests(Vec<(Bytes, Bytes)>);
+pub struct FixedInterests(Vec<RangeOpen<Bytes>>);
 
 impl FixedInterests {
     pub fn full() -> Self {
-        Self(vec![(Bytes::min_value(), Bytes::max_value())])
+        Self(vec![(Bytes::min_value(), Bytes::max_value()).into()])
     }
     pub fn is_full(&self) -> bool {
         self == &Self::full()
@@ -122,7 +122,7 @@ impl FixedInterests {
 impl InterestProvider for FixedInterests {
     type Key = Bytes;
 
-    fn interests(&self) -> anyhow::Result<Vec<(Self::Key, Self::Key)>> {
+    fn interests(&self) -> anyhow::Result<Vec<RangeOpen<Self::Key>>> {
         Ok(self.0.clone())
     }
 }
@@ -147,11 +147,11 @@ where
                 allocator.softline().append(
                     allocator
                         .intersperse(
-                            recon.interests().unwrap().iter().map(|(start, end)| {
+                            recon.interests().unwrap().iter().map(|range| {
                                 allocator
-                                    .text(start.to_string())
+                                    .text(range.start.to_string())
                                     .append(separator.clone())
-                                    .append(allocator.text(end.to_string()))
+                                    .append(allocator.text(range.end.to_string()))
                                     .parens()
                             }),
                             separator.clone(),
@@ -620,14 +620,14 @@ fn test_parse_recon() {
             cat: Recon {
                 interests: FixedInterests(
                     [
-                        (
-                            Bytes(
+                        RangeOpen {
+                            start: Bytes(
                                 "",
                             ),
-                            Bytes(
+                            end: Bytes(
                                 "0xFF",
                             ),
-                        ),
+                        },
                     ],
                 ),
                 store: BTreeStore {
@@ -704,14 +704,14 @@ fn test_parse_recon() {
             dog: Recon {
                 interests: FixedInterests(
                     [
-                        (
-                            Bytes(
+                        RangeOpen {
+                            start: Bytes(
                                 "",
                             ),
-                            Bytes(
+                            end: Bytes(
                                 "0xFF",
                             ),
-                        ),
+                        },
                     ],
                 ),
                 store: BTreeStore {
@@ -968,14 +968,14 @@ dog: []
             cat: Recon {
                 interests: FixedInterests(
                     [
-                        (
-                            Bytes(
+                        RangeOpen {
+                            start: Bytes(
                                 "",
                             ),
-                            Bytes(
+                            end: Bytes(
                                 "0xFF",
                             ),
-                        ),
+                        },
                     ],
                 ),
                 store: BTreeStore {
@@ -1008,14 +1008,14 @@ dog: []
             dog: Recon {
                 interests: FixedInterests(
                     [
-                        (
-                            Bytes(
+                        RangeOpen {
+                            start: Bytes(
                                 "",
                             ),
-                            Bytes(
+                            end: Bytes(
                                 "0xFF",
                             ),
-                        ),
+                        },
                     ],
                 ),
                 store: BTreeStore {


### PR DESCRIPTION
With these changes ceramic-one can do the following:

1. Maintain a set of interest ranges for itself and other peers
2. Synchronize interest ranges among peers
3. Use Recon to sync keys that exist within intersecting interest ranges.
4. Update its local interest when a subscription is requested.

Some things that are still lacking:

1. Interests are not expired
2. Interests are never removed from the local node
3. Interests are NOT signed but still shared with peers transitively 

This PR is large enough, I suggest we create issues for the above and address them in subsequent smaller PRs.

