### PR TITLE
fix: make signer send and allow jwk to be cloned

### DIFF
--- a/core/src/jwk.rs
+++ b/core/src/jwk.rs
@@ -10,7 +10,7 @@ static DID_TYPE_REGEX: Lazy<regex::Regex> =
     Lazy::new(|| regex::Regex::new(r#"did:(?P<T>[^:]+):(?P<K>[A-Za-z0-9:]+)"#).unwrap());
 
 /// Newtype around JWK to make it easier to construct from a DID and provide a private key
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Jwk(JWK);
 
 const DID_KEY: &str = "key";

--- a/core/src/signer.rs
+++ b/core/src/signer.rs
@@ -2,7 +2,7 @@ use crate::{Base64UrlString, DidDocument, Jwk};
 use ssi::jwk::Algorithm;
 
 /// Sign bytes for an id and algorithm
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 pub trait Signer {
     /// Algorithm used by signer
     fn algorithm(&self) -> Algorithm;
@@ -13,6 +13,7 @@ pub trait Signer {
 }
 
 /// Did and jwk based signer
+#[derive(Clone, Debug)]
 pub struct JwkSigner {
     did: DidDocument,
     jwk: Jwk,
@@ -29,7 +30,7 @@ impl JwkSigner {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl Signer for JwkSigner {
     fn algorithm(&self) -> Algorithm {
         Algorithm::EdDSA


### PR DESCRIPTION
Keramik needs signer to be signed. Will need a different approach for dapp functionality.