### PR TITLE
fix: wrap returned peers in "Peers" key

### DIFF
--- a/kubo-rpc-server.patch
+++ b/kubo-rpc-server.patch
@@ -1,5 +1,5 @@
 diff --git b/kubo-rpc-server/src/client/mod.rs a/kubo-rpc-server/src/client/mod.rs
-index ddb7167..916bd17 100644
+index 19eff91..f78219b 100644
 --- b/kubo-rpc-server/src/client/mod.rs
 +++ a/kubo-rpc-server/src/client/mod.rs
 @@ -1,7 +1,7 @@
@@ -28,7 +28,7 @@ index ddb7167..916bd17 100644
              400 => {
                  let body = response.into_body();
 diff --git b/kubo-rpc-server/src/lib.rs a/kubo-rpc-server/src/lib.rs
-index deb1393..9224938 100644
+index a438acd..68c986c 100644
 --- b/kubo-rpc-server/src/lib.rs
 +++ a/kubo-rpc-server/src/lib.rs
 @@ -11,7 +11,8 @@
@@ -69,7 +69,7 @@ index deb1393..9224938 100644
  #[must_use]
  pub enum SwarmConnectPostResponse {
 diff --git b/kubo-rpc-server/src/models.rs a/kubo-rpc-server/src/models.rs
-index e1080e6..60ba5e5 100644
+index 20d075b..7a6d6b8 100644
 --- b/kubo-rpc-server/src/models.rs
 +++ a/kubo-rpc-server/src/models.rs
 @@ -1037,7 +1037,7 @@ pub struct Error {

--- a/kubo-rpc-server/.openapi-generator/FILES
+++ b/kubo-rpc-server/.openapi-generator/FILES
@@ -16,7 +16,8 @@ docs/IdPost200Response.md
 docs/Multihash.md
 docs/PinAddPost200Response.md
 docs/PubsubLsPost200Response.md
-docs/SwarmPeersPost200ResponseInner.md
+docs/SwarmPeersPost200Response.md
+docs/SwarmPeersPost200ResponsePeersInner.md
 docs/VersionPost200Response.md
 docs/default_api.md
 examples/ca.pem

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.1.0
-- Build date: 2023-08-30T10:54:27.367-06:00[America/Denver]
+- Build date: 2023-08-30T16:59:47.807386943-06:00[America/Denver]
 
 
 
@@ -144,7 +144,8 @@ Method | HTTP request | Description
  - [Multihash](docs/Multihash.md)
  - [PinAddPost200Response](docs/PinAddPost200Response.md)
  - [PubsubLsPost200Response](docs/PubsubLsPost200Response.md)
- - [SwarmPeersPost200ResponseInner](docs/SwarmPeersPost200ResponseInner.md)
+ - [SwarmPeersPost200Response](docs/SwarmPeersPost200Response.md)
+ - [SwarmPeersPost200ResponsePeersInner](docs/SwarmPeersPost200ResponsePeersInner.md)
  - [VersionPost200Response](docs/VersionPost200Response.md)
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -393,9 +393,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/_swarm_peers_post_200_response_inner'
-                type: array
+                $ref: '#/components/schemas/_swarm_peers_post_200_response'
           description: success
         "400":
           content:
@@ -618,7 +616,7 @@ components:
       required:
       - Strings
       type: object
-    _swarm_peers_post_200_response_inner:
+    _swarm_peers_post_200_response_Peers_inner:
       example:
         Peer: Peer
         Addr: Addr
@@ -630,6 +628,21 @@ components:
       required:
       - Addr
       - Peer
+      type: object
+    _swarm_peers_post_200_response:
+      example:
+        Peers:
+        - Peer: Peer
+          Addr: Addr
+        - Peer: Peer
+          Addr: Addr
+      properties:
+        Peers:
+          items:
+            $ref: '#/components/schemas/_swarm_peers_post_200_response_Peers_inner'
+          type: array
+      required:
+      - Peers
       type: object
     _version_post_200_response:
       example:

--- a/kubo-rpc-server/docs/SwarmPeersPost200Response.md
+++ b/kubo-rpc-server/docs/SwarmPeersPost200Response.md
@@ -1,0 +1,10 @@
+# SwarmPeersPost200Response
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**peers** | [**Vec<models::SwarmPeersPost200ResponsePeersInner>**](_swarm_peers_post_200_response_Peers_inner.md) |  | 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/kubo-rpc-server/docs/SwarmPeersPost200ResponsePeersInner.md
+++ b/kubo-rpc-server/docs/SwarmPeersPost200ResponsePeersInner.md
@@ -1,0 +1,11 @@
+# SwarmPeersPost200ResponsePeersInner
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**addr** | **String** |  | 
+**peer** | **String** |  | 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/kubo-rpc-server/docs/default_api.md
+++ b/kubo-rpc-server/docs/default_api.md
@@ -418,7 +418,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # ****
-> Vec<models::SwarmPeersPost200ResponseInner> ()
+> models::SwarmPeersPost200Response ()
 Report connected peers
 
 ### Required Parameters
@@ -426,7 +426,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Vec<models::SwarmPeersPost200ResponseInner>**](_swarm_peers_post_200_response_inner.md)
+[**models::SwarmPeersPost200Response**](_swarm_peers_post_200_response.md)
 
 ### Authorization
 

--- a/kubo-rpc-server/src/client/mod.rs
+++ b/kubo-rpc-server/src/client/mod.rs
@@ -2044,11 +2044,10 @@ where
                     .await?;
                 let body = str::from_utf8(&body)
                     .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
-                let body =
-                    serde_json::from_str::<Vec<models::SwarmPeersPost200ResponseInner>>(body)
-                        .map_err(|e| {
-                            ApiError(format!("Response body did not match the schema: {}", e))
-                        })?;
+                let body = serde_json::from_str::<models::SwarmPeersPost200Response>(body)
+                    .map_err(|e| {
+                        ApiError(format!("Response body did not match the schema: {}", e))
+                    })?;
                 Ok(SwarmPeersPostResponse::Success(body))
             }
             400 => {

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -162,7 +162,7 @@ pub enum SwarmConnectPostResponse {
 #[must_use]
 pub enum SwarmPeersPostResponse {
     /// success
-    Success(Vec<models::SwarmPeersPost200ResponseInner>),
+    Success(models::SwarmPeersPost200Response),
     /// bad request
     BadRequest(models::Error),
 }

--- a/kubo-rpc-server/src/models.rs
+++ b/kubo-rpc-server/src/models.rs
@@ -1720,7 +1720,139 @@ impl std::convert::TryFrom<hyper::header::HeaderValue>
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct SwarmPeersPost200ResponseInner {
+pub struct SwarmPeersPost200Response {
+    #[serde(rename = "Peers")]
+    pub peers: Vec<models::SwarmPeersPost200ResponsePeersInner>,
+}
+
+impl SwarmPeersPost200Response {
+    #[allow(clippy::new_without_default)]
+    pub fn new(
+        peers: Vec<models::SwarmPeersPost200ResponsePeersInner>,
+    ) -> SwarmPeersPost200Response {
+        SwarmPeersPost200Response { peers }
+    }
+}
+
+/// Converts the SwarmPeersPost200Response value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::string::ToString for SwarmPeersPost200Response {
+    fn to_string(&self) -> String {
+        let params: Vec<Option<String>> = vec![
+            // Skipping Peers in query parameter serialization
+
+        ];
+
+        params.into_iter().flatten().collect::<Vec<_>>().join(",")
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a SwarmPeersPost200Response value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for SwarmPeersPost200Response {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub peers: Vec<Vec<models::SwarmPeersPost200ResponsePeersInner>>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing SwarmPeersPost200Response".to_string(),
+                    )
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    "Peers" => return std::result::Result::Err("Parsing a container in this style is not supported in SwarmPeersPost200Response".to_string()),
+                    _ => return std::result::Result::Err("Unexpected key while parsing SwarmPeersPost200Response".to_string())
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(SwarmPeersPost200Response {
+            peers: intermediate_rep
+                .peers
+                .into_iter()
+                .next()
+                .ok_or_else(|| "Peers missing in SwarmPeersPost200Response".to_string())?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<SwarmPeersPost200Response> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<SwarmPeersPost200Response>>
+    for hyper::header::HeaderValue
+{
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<SwarmPeersPost200Response>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Invalid header value for SwarmPeersPost200Response - value: {} is invalid {}",
+                hdr_value, e
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue>
+    for header::IntoHeaderValue<SwarmPeersPost200Response>
+{
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <SwarmPeersPost200Response as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        "Unable to convert header value '{}' into SwarmPeersPost200Response - {}",
+                        value, err
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert header: {:?} to string: {}",
+                hdr_value, e
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct SwarmPeersPost200ResponsePeersInner {
     #[serde(rename = "Addr")]
     pub addr: String,
 
@@ -1728,17 +1860,17 @@ pub struct SwarmPeersPost200ResponseInner {
     pub peer: String,
 }
 
-impl SwarmPeersPost200ResponseInner {
+impl SwarmPeersPost200ResponsePeersInner {
     #[allow(clippy::new_without_default)]
-    pub fn new(addr: String, peer: String) -> SwarmPeersPost200ResponseInner {
-        SwarmPeersPost200ResponseInner { addr, peer }
+    pub fn new(addr: String, peer: String) -> SwarmPeersPost200ResponsePeersInner {
+        SwarmPeersPost200ResponsePeersInner { addr, peer }
     }
 }
 
-/// Converts the SwarmPeersPost200ResponseInner value to the Query Parameters representation (style=form, explode=false)
+/// Converts the SwarmPeersPost200ResponsePeersInner value to the Query Parameters representation (style=form, explode=false)
 /// specified in https://swagger.io/docs/specification/serialization/
 /// Should be implemented in a serde serializer
-impl std::string::ToString for SwarmPeersPost200ResponseInner {
+impl std::string::ToString for SwarmPeersPost200ResponsePeersInner {
     fn to_string(&self) -> String {
         let params: Vec<Option<String>> = vec![
             Some("Addr".to_string()),
@@ -1751,10 +1883,10 @@ impl std::string::ToString for SwarmPeersPost200ResponseInner {
     }
 }
 
-/// Converts Query Parameters representation (style=form, explode=false) to a SwarmPeersPost200ResponseInner value
+/// Converts Query Parameters representation (style=form, explode=false) to a SwarmPeersPost200ResponsePeersInner value
 /// as specified in https://swagger.io/docs/specification/serialization/
 /// Should be implemented in a serde deserializer
-impl std::str::FromStr for SwarmPeersPost200ResponseInner {
+impl std::str::FromStr for SwarmPeersPost200ResponsePeersInner {
     type Err = String;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
@@ -1777,7 +1909,8 @@ impl std::str::FromStr for SwarmPeersPost200ResponseInner {
                 Some(x) => x,
                 None => {
                     return std::result::Result::Err(
-                        "Missing value while parsing SwarmPeersPost200ResponseInner".to_string(),
+                        "Missing value while parsing SwarmPeersPost200ResponsePeersInner"
+                            .to_string(),
                     )
                 }
             };
@@ -1795,7 +1928,7 @@ impl std::str::FromStr for SwarmPeersPost200ResponseInner {
                     ),
                     _ => {
                         return std::result::Result::Err(
-                            "Unexpected key while parsing SwarmPeersPost200ResponseInner"
+                            "Unexpected key while parsing SwarmPeersPost200ResponsePeersInner"
                                 .to_string(),
                         )
                     }
@@ -1807,56 +1940,55 @@ impl std::str::FromStr for SwarmPeersPost200ResponseInner {
         }
 
         // Use the intermediate representation to return the struct
-        std::result::Result::Ok(SwarmPeersPost200ResponseInner {
+        std::result::Result::Ok(SwarmPeersPost200ResponsePeersInner {
             addr: intermediate_rep
                 .addr
                 .into_iter()
                 .next()
-                .ok_or_else(|| "Addr missing in SwarmPeersPost200ResponseInner".to_string())?,
+                .ok_or_else(|| "Addr missing in SwarmPeersPost200ResponsePeersInner".to_string())?,
             peer: intermediate_rep
                 .peer
                 .into_iter()
                 .next()
-                .ok_or_else(|| "Peer missing in SwarmPeersPost200ResponseInner".to_string())?,
+                .ok_or_else(|| "Peer missing in SwarmPeersPost200ResponsePeersInner".to_string())?,
         })
     }
 }
 
-// Methods for converting between header::IntoHeaderValue<SwarmPeersPost200ResponseInner> and hyper::header::HeaderValue
+// Methods for converting between header::IntoHeaderValue<SwarmPeersPost200ResponsePeersInner> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl std::convert::TryFrom<header::IntoHeaderValue<SwarmPeersPost200ResponseInner>>
+impl std::convert::TryFrom<header::IntoHeaderValue<SwarmPeersPost200ResponsePeersInner>>
     for hyper::header::HeaderValue
 {
     type Error = String;
 
     fn try_from(
-        hdr_value: header::IntoHeaderValue<SwarmPeersPost200ResponseInner>,
+        hdr_value: header::IntoHeaderValue<SwarmPeersPost200ResponsePeersInner>,
     ) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                "Invalid header value for SwarmPeersPost200ResponseInner - value: {} is invalid {}",
-                hdr_value, e
-            )),
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for SwarmPeersPost200ResponsePeersInner - value: {} is invalid {}",
+                     hdr_value, e))
         }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
 impl std::convert::TryFrom<hyper::header::HeaderValue>
-    for header::IntoHeaderValue<SwarmPeersPost200ResponseInner>
+    for header::IntoHeaderValue<SwarmPeersPost200ResponsePeersInner>
 {
     type Error = String;
 
     fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
              std::result::Result::Ok(value) => {
-                    match <SwarmPeersPost200ResponseInner as std::str::FromStr>::from_str(value) {
+                    match <SwarmPeersPost200ResponsePeersInner as std::str::FromStr>::from_str(value) {
                         std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
                         std::result::Result::Err(err) => std::result::Result::Err(
-                            format!("Unable to convert header value '{}' into SwarmPeersPost200ResponseInner - {}",
+                            format!("Unable to convert header value '{}' into SwarmPeersPost200ResponsePeersInner - {}",
                                 value, err))
                     }
              },

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -490,17 +490,22 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  required:
-                    - Addr
-                    - Peer
-                  properties:
-                    Addr:
-                      type: string
-                    Peer:
-                      type: string
+                type: object
+                required:
+                  - Peers
+                properties:
+                  Peers:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - Addr
+                        - Peer
+                      properties:
+                        Addr:
+                          type: string
+                        Peer:
+                          type: string
         '400':
           description: bad request
           content:


### PR DESCRIPTION
The change to openapi for kubo dropped the `Peers` key from the /swarm/peers endpoint. This fixes it.