### PR TITLE
fix: change bitswap dial behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,7 +1389,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "prometheus-client",
- "rand 0.8.5",
  "recon",
  "serde",
  "serde_json",

--- a/beetle/iroh-bitswap/src/client/peer_manager.rs
+++ b/beetle/iroh-bitswap/src/client/peer_manager.rs
@@ -254,7 +254,7 @@ impl PeerManager {
         let _ = r.await;
     }
 
-    /// Indicates wether peers have been discovered yet.
+    /// Indicates whether peers have been discovered yet.
     pub async fn peers_discovered_for_session(&self, session: u64) -> bool {
         let (s, r) = oneshot::channel();
         self.send(Message::PeersDiscoveredForSession {

--- a/beetle/iroh-bitswap/src/client/peer_want_manager.rs
+++ b/beetle/iroh-bitswap/src/client/peer_want_manager.rs
@@ -1,7 +1,7 @@
 use ahash::{AHashMap, AHashSet};
 use cid::Cid;
 use libp2p::PeerId;
-use tracing::{debug, error};
+use tracing::{debug, error, trace};
 
 use super::message_queue::MessageQueue;
 use super::peer_manager::PeerState;
@@ -33,6 +33,7 @@ impl PeerWantManager {
             return;
         }
 
+        trace!(%peer, "add_peer");
         self.peer_wants.insert(
             *peer,
             PeerWant {
@@ -50,6 +51,7 @@ impl PeerWantManager {
 
     /// Removes a peer and its associated wants from tracking.
     pub fn remove_peer(&mut self, peer: &PeerId) {
+        trace!(%peer, "remove_peer");
         if let Some(peer_wants) = self.peer_wants.remove(peer) {
             // Clean up want-block
             for cid in peer_wants.want_blocks {

--- a/kubo-rpc/Cargo.toml
+++ b/kubo-rpc/Cargo.toml
@@ -9,12 +9,7 @@ repository.workspace = true
 publish = false
 
 [features]
-http = [
-    "dep:ceramic-kubo-rpc-server",
-    "dep:serde",
-    "dep:serde_json",
-    "dep:hyper",
-]
+http = ["dep:ceramic-kubo-rpc-server", "dep:serde", "dep:serde_json", "dep:hyper"]
 
 [dependencies]
 anyhow.workspace = true

--- a/one/Cargo.toml
+++ b/one/Cargo.toml
@@ -41,7 +41,6 @@ tracing-appender = "0.2.2"
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
-rand = "0.8.5"
 ceramic-core.workspace = true
 hyper.workspace = true
 swagger.workspace = true


### PR DESCRIPTION
Prior to this change bitswap assumed it was the only behaviour asking the swarm to dial peers, as such when a dial failure occurred it marked the peer as failed and would not send want-haves to the peer.

However this behavior did not work well with the behavior to auto discover ceramic peers and dial them. When ceramic peers were discovered it was possible that they were already connected in which case the `DialFailedPrecondition` error would be reported causing bitswap to mark the peer as failed even though we have a valid connection open to the peer.

This change modifies the bitswap behavior to only modify peer state when a connection closed event is received instead of dial failures. A peer is not marked as good until a connection is established so marking a peer as failed when the connection closes is a valid/consistent behavior.

A few small changes are also made in order to improve debugging.