### PR TITLE
fix: change pubsub/ls to return base64url encoded topics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,7 @@ dependencies = [
  "mockall",
  "multiaddr",
  "multihash 0.17.0",
+ "pin-project",
  "serde",
  "serde_json",
  "swagger",

--- a/kubo-rpc/Cargo.toml
+++ b/kubo-rpc/Cargo.toml
@@ -11,9 +11,10 @@ publish = false
 [features]
 http = [
     "dep:ceramic-kubo-rpc-server",
+    "dep:hyper",
+    "dep:pin-project",
     "dep:serde",
     "dep:serde_json",
-    "dep:hyper",
 ]
 
 [dependencies]
@@ -29,8 +30,8 @@ dag-jose.workspace = true
 futures-util.workspace = true
 hex.workspace = true
 hyper = { workspace = true, optional = true }
-iroh-car.workspace = true
 iroh-bitswap.workspace = true
+iroh-car.workspace = true
 iroh-metrics.workspace = true
 iroh-rpc-client.workspace = true
 iroh-rpc-types.workspace = true
@@ -42,15 +43,16 @@ libp2p-tls.workspace = true
 libp2p.workspace = true
 multiaddr.workspace = true
 multihash.workspace = true
+pin-project = { version = "1.1.3", optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 swagger.workspace = true
+thiserror = "1.0.47"
 tokio-stream = "0.1.14"
 tokio-util.workspace = true
 tokio.workspace = true
 tracing-opentelemetry.workspace = true
 tracing.workspace = true
-thiserror = "1.0.47"
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/kubo-rpc/src/http/stream_drop.rs
+++ b/kubo-rpc/src/http/stream_drop.rs
@@ -1,0 +1,57 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures_util::{Future, Stream};
+use pin_project::{pin_project, pinned_drop};
+
+/// Wraps a stream and on drop spawns a future as its own task.
+/// The future is not gauranteed to complete.
+#[pin_project(PinnedDrop)]
+pub struct StreamDrop<S, D>
+where
+    D: Future<Output = ()> + Send + 'static,
+{
+    #[pin]
+    stream: S,
+    drop_fut: Option<D>,
+}
+
+impl<S, D> StreamDrop<S, D>
+where
+    D: Future<Output = ()> + Send + 'static,
+{
+    pub fn new(stream: S, drop_fn: D) -> Self {
+        Self {
+            stream,
+            drop_fut: Some(drop_fn),
+        }
+    }
+}
+
+impl<S, D> Stream for StreamDrop<S, D>
+where
+    S: Stream,
+    D: Future<Output = ()> + Send + 'static,
+{
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        Stream::poll_next(this.stream, cx)
+    }
+}
+
+#[pinned_drop]
+impl<S, D> PinnedDrop for StreamDrop<S, D>
+where
+    D: Future<Output = ()> + Send + 'static,
+{
+    fn drop(self: Pin<&mut Self>) {
+        let this = self.project();
+        if let Some(drop_fn) = this.drop_fut.take() {
+            tokio::spawn(drop_fn);
+        }
+    }
+}

--- a/kubo-rpc/src/pubsub.rs
+++ b/kubo-rpc/src/pubsub.rs
@@ -24,6 +24,14 @@ where
 {
     client.subscribe(topic).await
 }
+/// Unsubscribe from a topic
+#[tracing::instrument(skip(client), ret)]
+pub async fn unsubscribe<T>(client: T, topic: String) -> Result<(), Error>
+where
+    T: IpfsDep,
+{
+    client.unsubscribe(topic).await
+}
 /// Returns a list of topics, to which we are currently subscribed.
 #[tracing::instrument(skip(client))]
 pub async fn topics<T>(client: T) -> Result<Vec<String>, Error>


### PR DESCRIPTION
Prior to this change the pubsub/ls endpoint would return the raw topic names when the should be base64url encoded names.

Additionally the subscription would remain even after the subscription connection had closed. This is now fixed.