### PR TITLE
fix: optimize sqlx pool options

### DIFF
--- a/one/src/sql.rs
+++ b/one/src/sql.rs
@@ -1,10 +1,14 @@
 use std::path::Path;
 
 use anyhow::Result;
-use sqlx::sqlite::SqlitePool;
+use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
 
 pub async fn connect(path: impl AsRef<Path>) -> Result<SqlitePool> {
-    let pool = SqlitePool::connect(&format!("sqlite:{}?mode=rwc", path.as_ref().display())).await?;
+    let pool = SqlitePoolOptions::new()
+        // sqlite performs best with a single active connection at a time.
+        .max_connections(1)
+        .connect(&format!("sqlite:{}?mode=rwc", path.as_ref().display()))
+        .await?;
 
     // set the WAL PRAGMA for faster writes
     const SET_WAL_PRAGMA: &str = "PRAGMA journal_mode=wal;";


### PR DESCRIPTION
We were seeing connection pool timeouts under heavy concurrent write load. I determined the sqlite prefers to have a single active connection at a time and to queue the rest of the work in the `acquire` stage.

I tested this by running the daemon process with restricted resources, specifically 2 CPUs 1GB RAM and only 64 IOPS. I then wrote 5K unique blocks that were each ~512 bytes. The concurrency was 2K for writing blocks.

With default settings on the order of 1% of writes would fail with repeated tests. With changing the settings to a single active connection the failure rate was 0% with repeated tests.

I also tests with even fewer IOPS to see higher failure rates and confirmed that 1 active connection performed best.

Finally I tested increasing the active connections to really high values 1K+. This resulted in `database is locked` errors and worse performance.