### PR TITLE
fix: append peer id to all listen addrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,6 +1303,7 @@ dependencies = [
  "libp2p-tls",
  "mockall",
  "multiaddr",
+ "multihash 0.17.0",
  "serde",
  "serde_json",
  "swagger",

--- a/kubo-rpc/Cargo.toml
+++ b/kubo-rpc/Cargo.toml
@@ -9,7 +9,12 @@ repository.workspace = true
 publish = false
 
 [features]
-http = ["dep:ceramic-kubo-rpc-server", "dep:serde", "dep:serde_json", "dep:hyper"]
+http = [
+    "dep:ceramic-kubo-rpc-server",
+    "dep:serde",
+    "dep:serde_json",
+    "dep:hyper",
+]
 
 [dependencies]
 anyhow.workspace = true
@@ -36,6 +41,7 @@ libp2p-identity.workspace = true
 libp2p-tls.workspace = true
 libp2p.workspace = true
 multiaddr.workspace = true
+multihash.workspace = true
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 swagger.workspace = true

--- a/kubo-rpc/src/http.rs
+++ b/kubo-rpc/src/http.rs
@@ -1204,8 +1204,8 @@ mod tests {
                 IdPost200Response {
                     id: "12D3KooWQuKj4A11GNZ4MmcAmJzCNGZjArjyRTgkLhSutqeqVypv",
                     addresses: [
-                        "/ip4/127.0.0.1/udp/35826/quic-v1",
-                        "/ip4/192.168.12.189/tcp/43113",
+                        "/ip4/127.0.0.1/udp/35826/quic-v1/p2p/12D3KooWQuKj4A11GNZ4MmcAmJzCNGZjArjyRTgkLhSutqeqVypv",
+                        "/ip4/192.168.12.189/tcp/43113/p2p/12D3KooWQuKj4A11GNZ4MmcAmJzCNGZjArjyRTgkLhSutqeqVypv",
                     ],
                     agent_version: "iroh/0.2.0",
                     protocol_version: "ipfs/0.1.0",
@@ -1278,8 +1278,8 @@ mod tests {
                 IdPost200Response {
                     id: "12D3KooWQuKj4A11GNZ4MmcAmJzCNGZjArjyRTgkLhSutqeqVypv",
                     addresses: [
-                        "/ip4/127.0.0.1/udp/35826/quic-v1",
-                        "/ip4/192.168.12.189/tcp/43113",
+                        "/ip4/127.0.0.1/udp/35826/quic-v1/p2p/12D3KooWQuKj4A11GNZ4MmcAmJzCNGZjArjyRTgkLhSutqeqVypv",
+                        "/ip4/192.168.12.189/tcp/43113/p2p/12D3KooWQuKj4A11GNZ4MmcAmJzCNGZjArjyRTgkLhSutqeqVypv",
                     ],
                     agent_version: "iroh/0.2.0",
                     protocol_version: "ipfs/0.1.0",

--- a/kubo-rpc/src/id.rs
+++ b/kubo-rpc/src/id.rs
@@ -1,4 +1,7 @@
 //! Provides methods for looking up peer info.
+
+use multihash::Multihash;
+
 use crate::{error::Error, IpfsDep, PeerId, PeerInfo};
 
 /// Lookup information about a specific peer.
@@ -7,12 +10,32 @@ pub async fn lookup<T>(client: T, peer_id: PeerId) -> Result<PeerInfo, Error>
 where
     T: IpfsDep,
 {
-    client.lookup(peer_id).await
+    Ok(add_peer_id_to_addrs(client.lookup(peer_id).await?))
 }
 /// Lookup information about the local peer.
 pub async fn lookup_local<T>(client: T) -> Result<PeerInfo, Error>
 where
     T: IpfsDep,
 {
-    client.lookup_local().await
+    Ok(add_peer_id_to_addrs(client.lookup_local().await?))
+}
+
+// Adds the peer's own peer ID to its listen_addrs if it's not already present.
+fn add_peer_id_to_addrs(mut peer: PeerInfo) -> PeerInfo {
+    let peer_mh: Multihash = peer.peer_id.into();
+    peer.listen_addrs = peer
+        .listen_addrs
+        .into_iter()
+        .map(|addr| {
+            if !addr
+                .iter()
+                .any(|addr| matches!(addr, multiaddr::Protocol::P2p(_)))
+            {
+                addr.with(multiaddr::Protocol::P2p(peer_mh))
+            } else {
+                addr
+            }
+        })
+        .collect();
+    peer
 }


### PR DESCRIPTION
This change follows Kubo's implementation and is helpful for clients as then can simply iterate through the list of addrs when attempt to peer with them instead of having to construct the full mulitaddr themselves.