### PR TITLE
fix: add block get timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,6 +1288,7 @@ dependencies = [
  "dag-jose",
  "expect-test",
  "futures-util",
+ "go-parse-duration",
  "hex",
  "hyper",
  "iroh-bitswap",
@@ -3351,6 +3352,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "go-parse-duration"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558b88954871f5e5b2af0e62e2e176c8bde7a6c2c4ed41b13d138d96da2e2cbd"
 
 [[package]]
 name = "grdf"

--- a/kubo-rpc-server.patch
+++ b/kubo-rpc-server.patch
@@ -1,5 +1,5 @@
 diff --git b/kubo-rpc-server/src/client/mod.rs a/kubo-rpc-server/src/client/mod.rs
-index 19eff91..f78219b 100644
+index 25e2d35..01c7446 100644
 --- b/kubo-rpc-server/src/client/mod.rs
 +++ a/kubo-rpc-server/src/client/mod.rs
 @@ -1,7 +1,7 @@
@@ -11,7 +11,7 @@ index 19eff91..f78219b 100644
  };
  use hyper::header::{HeaderName, HeaderValue, CONTENT_TYPE};
  use hyper::{service::Service, Body, Request, Response, Uri};
-@@ -1846,12 +1846,9 @@ where
+@@ -1863,12 +1863,9 @@ where
          match response.status().as_u16() {
              200 => {
                  let body = response.into_body();
@@ -28,7 +28,7 @@ index 19eff91..f78219b 100644
              400 => {
                  let body = response.into_body();
 diff --git b/kubo-rpc-server/src/lib.rs a/kubo-rpc-server/src/lib.rs
-index 4fb7cb1..bd4e190 100644
+index 30c3be6..3b742d0 100644
 --- b/kubo-rpc-server/src/lib.rs
 +++ a/kubo-rpc-server/src/lib.rs
 @@ -11,7 +11,8 @@
@@ -41,7 +41,7 @@ index 4fb7cb1..bd4e190 100644
  use serde::{Deserialize, Serialize};
  use std::error::Error;
  use std::task::{Context, Poll};
-@@ -130,15 +131,24 @@ pub enum PubsubPubPostResponse {
+@@ -132,15 +133,24 @@ pub enum PubsubPubPostResponse {
      BadRequest(models::Error),
  }
  
@@ -109,10 +109,10 @@ index 4644ce0..ce429ca 100644
                  .into_iter()
                  .next()
 diff --git b/kubo-rpc-server/src/server/mod.rs a/kubo-rpc-server/src/server/mod.rs
-index b0bf249..960f3c1 100644
+index c49265a..2a1e066 100644
 --- b/kubo-rpc-server/src/server/mod.rs
 +++ a/kubo-rpc-server/src/server/mod.rs
-@@ -1456,8 +1456,8 @@ where
+@@ -1488,8 +1488,8 @@ where
                                                          CONTENT_TYPE,
                                                          HeaderValue::from_str("application/octet-stream")
                                                              .expect("Unable to create Content-Type header for PUBSUB_SUB_POST_SUCCESS"));

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.1.1
-- Build date: 2023-09-26T22:40:03.737-06:00[America/Mexico_City]
+- Build date: 2023-10-17T15:41:15.649942585-06:00[America/Denver]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -141,6 +141,14 @@ paths:
         schema:
           type: string
         style: form
+      - description: Max duration (as Go duration string) to wait to find the block
+        explode: true
+        in: query
+        name: timeout
+        required: false
+        schema:
+          type: string
+        style: form
       responses:
         "200":
           content:
@@ -155,6 +163,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: bad request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: internal error
       summary: Get a single IPFS block
   /block/put:
     post:

--- a/kubo-rpc-server/docs/default_api.md
+++ b/kubo-rpc-server/docs/default_api.md
@@ -23,7 +23,7 @@ Method | HTTP request | Description
 
 
 # ****
-> swagger::ByteArray (arg)
+> swagger::ByteArray (arg, optional)
 Get a single IPFS block
 
 ### Required Parameters
@@ -31,6 +31,15 @@ Get a single IPFS block
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
   **arg** | **String**| CID of block | 
+ **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a map[string]interface{}.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **arg** | **String**| CID of block | 
+ **timeout** | **String**| Max duration (as Go duration string) to wait to find the block | 
 
 ### Return type
 

--- a/kubo-rpc-server/examples/client/main.rs
+++ b/kubo-rpc-server/examples/client/main.rs
@@ -108,7 +108,10 @@ fn main() {
 
     match matches.value_of("operation") {
         Some("BlockGetPost") => {
-            let result = rt.block_on(client.block_get_post("arg_example".to_string()));
+            let result = rt.block_on(client.block_get_post(
+                "arg_example".to_string(),
+                Some("timeout_example".to_string()),
+            ));
             info!(
                 "{:?} (X-Span-ID: {:?})",
                 result,

--- a/kubo-rpc-server/examples/server/server.rs
+++ b/kubo-rpc-server/examples/server/server.rs
@@ -118,12 +118,14 @@ where
     async fn block_get_post(
         &self,
         arg: String,
+        timeout: Option<String>,
         context: &C,
     ) -> Result<BlockGetPostResponse, ApiError> {
         let context = context.clone();
         info!(
-            "block_get_post(\"{}\") - X-Span-ID: {:?}",
+            "block_get_post(\"{}\", {:?}) - X-Span-ID: {:?}",
             arg,
+            timeout,
             context.get().0.clone()
         );
         Err(ApiError("Generic failure".into()))

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -30,6 +30,8 @@ pub enum BlockGetPostResponse {
     Success(swagger::ByteArray),
     /// bad request
     BadRequest(models::Error),
+    /// internal error
+    InternalError(models::Error),
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -191,6 +193,7 @@ pub trait Api<C: Send + Sync> {
     async fn block_get_post(
         &self,
         arg: String,
+        timeout: Option<String>,
         context: &C,
     ) -> Result<BlockGetPostResponse, ApiError>;
 
@@ -301,7 +304,11 @@ pub trait ApiNoContext<C: Send + Sync> {
     fn context(&self) -> &C;
 
     /// Get a single IPFS block
-    async fn block_get_post(&self, arg: String) -> Result<BlockGetPostResponse, ApiError>;
+    async fn block_get_post(
+        &self,
+        arg: String,
+        timeout: Option<String>,
+    ) -> Result<BlockGetPostResponse, ApiError>;
 
     /// Put a single IPFS block
     async fn block_put_post(
@@ -405,9 +412,13 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     }
 
     /// Get a single IPFS block
-    async fn block_get_post(&self, arg: String) -> Result<BlockGetPostResponse, ApiError> {
+    async fn block_get_post(
+        &self,
+        arg: String,
+        timeout: Option<String>,
+    ) -> Result<BlockGetPostResponse, ApiError> {
         let context = self.context().clone();
-        self.api().block_get_post(arg, &context).await
+        self.api().block_get_post(arg, timeout, &context).await
     }
 
     /// Put a single IPFS block

--- a/kubo-rpc/Cargo.toml
+++ b/kubo-rpc/Cargo.toml
@@ -53,6 +53,7 @@ tokio-util.workspace = true
 tokio.workspace = true
 tracing-opentelemetry.workspace = true
 tracing.workspace = true
+go-parse-duration = "0.1.1"
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -193,6 +193,12 @@ paths:
           schema:
             type: string
           required: true
+        - name: timeout
+          in: query
+          description: Max duration (as Go duration string) to wait to find the block
+          schema:
+            type: string
+          required: false
       responses:
         '200':
           description: success
@@ -203,6 +209,12 @@ paths:
                 format: binary
         '400':
           description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: internal error
           content:
             application/json:
               schema:


### PR DESCRIPTION
There is an undocumented `timeout` query parameter to the `block/get` Kubo RPC endpoint that the js-ceramic code relies on. This change adds an implementation of that argument.

TODO:

- [x]  ~Decide if we should emulate the Go error string or allow the Rust specific error string to be reported.~ We are emulating the Go error string.