### PR TITLE
feat: add offline parameter to block/get

### DIFF
--- a/kubo-rpc-server.patch
+++ b/kubo-rpc-server.patch
@@ -1,5 +1,5 @@
 diff --git b/kubo-rpc-server/src/client/mod.rs a/kubo-rpc-server/src/client/mod.rs
-index 25e2d35..01c7446 100644
+index b248a1d..fc1f694 100644
 --- b/kubo-rpc-server/src/client/mod.rs
 +++ a/kubo-rpc-server/src/client/mod.rs
 @@ -1,7 +1,7 @@
@@ -11,7 +11,7 @@ index 25e2d35..01c7446 100644
  };
  use hyper::header::{HeaderName, HeaderValue, CONTENT_TYPE};
  use hyper::{service::Service, Body, Request, Response, Uri};
-@@ -1863,12 +1863,9 @@ where
+@@ -1867,12 +1867,9 @@ where
          match response.status().as_u16() {
              200 => {
                  let body = response.into_body();
@@ -28,7 +28,7 @@ index 25e2d35..01c7446 100644
              400 => {
                  let body = response.into_body();
 diff --git b/kubo-rpc-server/src/lib.rs a/kubo-rpc-server/src/lib.rs
-index 30c3be6..3b742d0 100644
+index e6c7274..65fafc5 100644
 --- b/kubo-rpc-server/src/lib.rs
 +++ a/kubo-rpc-server/src/lib.rs
 @@ -11,7 +11,8 @@
@@ -109,10 +109,10 @@ index 4644ce0..ce429ca 100644
                  .into_iter()
                  .next()
 diff --git b/kubo-rpc-server/src/server/mod.rs a/kubo-rpc-server/src/server/mod.rs
-index c49265a..2a1e066 100644
+index de4300c..f4f7ac3 100644
 --- b/kubo-rpc-server/src/server/mod.rs
 +++ a/kubo-rpc-server/src/server/mod.rs
-@@ -1488,8 +1488,8 @@ where
+@@ -1507,8 +1507,8 @@ where
                                                          CONTENT_TYPE,
                                                          HeaderValue::from_str("application/octet-stream")
                                                              .expect("Unable to create Content-Type header for PUBSUB_SUB_POST_SUCCESS"));

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.1.1
-- Build date: 2023-10-17T15:41:15.649942585-06:00[America/Denver]
+- Build date: 2023-10-24T14:51:02.668977965-06:00[America/Denver]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -149,6 +149,15 @@ paths:
         schema:
           type: string
         style: form
+      - description: "When true the peer will not consult other peers for the block,\
+          \ defaults to false."
+        explode: true
+        in: query
+        name: offline
+        required: false
+        schema:
+          type: bool
+        style: form
       responses:
         "200":
           content:

--- a/kubo-rpc-server/docs/default_api.md
+++ b/kubo-rpc-server/docs/default_api.md
@@ -40,6 +40,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **arg** | **String**| CID of block | 
  **timeout** | **String**| Max duration (as Go duration string) to wait to find the block | 
+ **offline** | [****](.md)| When true the peer will not consult other peers for the block, defaults to false. | 
 
 ### Return type
 

--- a/kubo-rpc-server/examples/client/main.rs
+++ b/kubo-rpc-server/examples/client/main.rs
@@ -111,6 +111,7 @@ fn main() {
             let result = rt.block_on(client.block_get_post(
                 "arg_example".to_string(),
                 Some("timeout_example".to_string()),
+                None,
             ));
             info!(
                 "{:?} (X-Span-ID: {:?})",

--- a/kubo-rpc-server/examples/server/server.rs
+++ b/kubo-rpc-server/examples/server/server.rs
@@ -119,13 +119,15 @@ where
         &self,
         arg: String,
         timeout: Option<String>,
+        offline: Option<bool>,
         context: &C,
     ) -> Result<BlockGetPostResponse, ApiError> {
         let context = context.clone();
         info!(
-            "block_get_post(\"{}\", {:?}) - X-Span-ID: {:?}",
+            "block_get_post(\"{}\", {:?}, {:?}) - X-Span-ID: {:?}",
             arg,
             timeout,
+            offline,
             context.get().0.clone()
         );
         Err(ApiError("Generic failure".into()))

--- a/kubo-rpc-server/src/client/mod.rs
+++ b/kubo-rpc-server/src/client/mod.rs
@@ -400,6 +400,7 @@ where
         &self,
         param_arg: String,
         param_timeout: Option<String>,
+        param_offline: Option<bool>,
         context: &C,
     ) -> Result<BlockGetPostResponse, ApiError> {
         let mut client_service = self.client_service.clone();
@@ -411,6 +412,9 @@ where
             query_string.append_pair("arg", &param_arg);
             if let Some(param_timeout) = param_timeout {
                 query_string.append_pair("timeout", &param_timeout);
+            }
+            if let Some(param_offline) = param_offline {
+                query_string.append_pair("offline", &param_offline.to_string());
             }
             query_string.finish()
         };

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -194,6 +194,7 @@ pub trait Api<C: Send + Sync> {
         &self,
         arg: String,
         timeout: Option<String>,
+        offline: Option<bool>,
         context: &C,
     ) -> Result<BlockGetPostResponse, ApiError>;
 
@@ -308,6 +309,7 @@ pub trait ApiNoContext<C: Send + Sync> {
         &self,
         arg: String,
         timeout: Option<String>,
+        offline: Option<bool>,
     ) -> Result<BlockGetPostResponse, ApiError>;
 
     /// Put a single IPFS block
@@ -416,9 +418,12 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
         &self,
         arg: String,
         timeout: Option<String>,
+        offline: Option<bool>,
     ) -> Result<BlockGetPostResponse, ApiError> {
         let context = self.context().clone();
-        self.api().block_get_post(arg, timeout, &context).await
+        self.api()
+            .block_get_post(arg, timeout, offline, &context)
+            .await
     }
 
     /// Put a single IPFS block

--- a/kubo-rpc-server/src/server/mod.rs
+++ b/kubo-rpc-server/src/server/mod.rs
@@ -232,9 +232,28 @@ where
                         }
                         None => None,
                     };
+                    let param_offline = query_params
+                        .iter()
+                        .filter(|e| e.0 == "offline")
+                        .map(|e| e.1.clone())
+                        .next();
+                    let param_offline = match param_offline {
+                        Some(param_offline) => {
+                            let param_offline =
+                                <bool as std::str::FromStr>::from_str(&param_offline);
+                            match param_offline {
+                            Ok(param_offline) => Some(param_offline),
+                            Err(e) => return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Body::from(format!("Couldn't parse query parameter offline - doesn't match schema: {}", e)))
+                                .expect("Unable to create Bad Request response for invalid query parameter offline")),
+                        }
+                        }
+                        None => None,
+                    };
 
                     let result = api_impl
-                        .block_get_post(param_arg, param_timeout, &context)
+                        .block_get_post(param_arg, param_timeout, param_offline, &context)
                         .await;
                     let mut response = Response::new(Body::empty());
                     response.headers_mut().insert(

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -199,6 +199,12 @@ paths:
           schema:
             type: string
           required: false
+        - name: offline
+          in: query
+          description: When true the peer will not consult other peers for the block, defaults to false.
+          schema:
+            type: bool
+          required: false
       responses:
         '200':
           description: success

--- a/kubo-rpc/src/block.rs
+++ b/kubo-rpc/src/block.rs
@@ -10,11 +10,11 @@ use crate::{error::Error, IpfsDep};
 
 /// Get a block from IPFS.
 #[tracing::instrument(skip(client))]
-pub async fn get<T>(client: T, cid: Cid) -> Result<Vec<u8>, Error>
+pub async fn get<T>(client: T, cid: Cid, offline: bool) -> Result<Vec<u8>, Error>
 where
     T: IpfsDep,
 {
-    let bytes = client.block_get(cid).await?;
+    let bytes = client.block_get(cid, offline).await?;
     Ok(bytes.to_vec())
 }
 


### PR DESCRIPTION
Adds another undocumented parameter to block/get. Offline indicates the node should not ask the network for the block but instead only check its own store.