### PR TITLE
fix: use rust-builder latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/r5b3e0r5/3box/rust-builder:debian-latest as builder
+FROM public.ecr.aws/r5b3e0r5/3box/rust-builder:latest as builder
 
 RUN mkdir -p /home/builder/rust-ceramic
 WORKDIR /home/builder/rust-ceramic


### PR DESCRIPTION
Rust-builder uses only the latest tag now.