### PR TITLE
feat: add explicit log format CLI option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9135,6 +9135,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9144,12 +9154,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,11 @@ tower-http = "0.3"
 tower-layer = "0.3"
 tracing = "0.1"
 tracing-opentelemetry = "0.18"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = [
+    "ansi",
+    "env-filter",
+    "json",
+] }
 tracing-test = { version = "0.2" }
 trust-dns-resolver = "0.22.0"
 unsigned-varint = "0.7"

--- a/beetle/iroh-metrics/src/config.rs
+++ b/beetle/iroh-metrics/src/config.rs
@@ -26,6 +26,20 @@ pub struct Config {
     #[cfg(feature = "tokio-console")]
     /// Enables tokio console debugging.
     pub tokio_console: bool,
+    /// How to print log lines to STDOUT
+    pub log_format: LogFormat,
+}
+
+/// Format of log events
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum LogFormat {
+    // Print log lines on multiple lines
+    #[default]
+    MultiLine,
+    // Print log lines on a single line
+    SingleLine,
+    // Print logs a newline delimited JSON
+    Json,
 }
 
 impl Config {
@@ -58,6 +72,7 @@ impl Default for Config {
             prom_gateway_endpoint: "http://localhost:9091".to_string(),
             #[cfg(feature = "tokio-console")]
             tokio_console: false,
+            log_format: LogFormat::default(),
         }
     }
 }


### PR DESCRIPTION
There are now three log format options.
* Single Line - Uses colors and everything is on a single line
* Multi Line - Uses colors and multiple lines to display more context
* JSON - Does not use colors and formats add structures as JSON on a single line.

This change also makes the default log level INFO.

Fixes WS1-1292