### PR TITLE
fix: remove Ceramic peer discovery

### DIFF
--- a/one/src/main.rs
+++ b/one/src/main.rs
@@ -276,13 +276,7 @@ impl Daemon {
             None
         };
         let ipfs = Ipfs::builder()
-            .with_p2p(
-                p2p_config,
-                keypair,
-                recons,
-                &network.name(),
-                sql_pool.clone(),
-            )
+            .with_p2p(p2p_config, keypair, recons, sql_pool.clone())
             .await?
             .build(sql_pool.clone())
             .await?;

--- a/one/src/network.rs
+++ b/one/src/network.rs
@@ -39,7 +39,6 @@ impl Builder<Init> {
         libp2p_config: Libp2pConfig,
         keypair: Keypair,
         recons: Option<(I, M)>,
-        ceramic_peers_key: &str,
         sql_pool: SqlitePool,
     ) -> anyhow::Result<Builder<WithP2p>>
     where
@@ -52,15 +51,7 @@ impl Builder<Init> {
 
         config.libp2p = libp2p_config;
 
-        let mut p2p = Node::new(
-            config,
-            addr.clone(),
-            keypair,
-            recons,
-            ceramic_peers_key,
-            sql_pool,
-        )
-        .await?;
+        let mut p2p = Node::new(config, addr.clone(), keypair, recons, sql_pool).await?;
 
         let task = task::spawn(async move {
             if let Err(err) = p2p.run().await {

--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -6,23 +6,22 @@ use ceramic_core::{EventId, Interest};
 use cid::Cid;
 use iroh_bitswap::{Bitswap, Block, Config as BitswapConfig, Store};
 use iroh_rpc_client::Client;
-use libp2p::gossipsub::{self, MessageAuthenticity};
-use libp2p::identify;
-use libp2p::kad::{
-    self,
-    store::{MemoryStore, MemoryStoreConfig},
-    RecordKey,
-};
-use libp2p::mdns::tokio::Behaviour as Mdns;
-use libp2p::multiaddr::Protocol;
-use libp2p::ping::Behaviour as Ping;
-use libp2p::relay;
-use libp2p::swarm::behaviour::toggle::Toggle;
-use libp2p::swarm::NetworkBehaviour;
-use libp2p::{autonat, dcutr};
 use libp2p::{
+    autonat,
     connection_limits::{self, ConnectionLimits},
-    kad::QueryId,
+    dcutr,
+    gossipsub::{self, MessageAuthenticity},
+    identify,
+    kad::{
+        self,
+        store::{MemoryStore, MemoryStoreConfig},
+    },
+    mdns::tokio::Behaviour as Mdns,
+    multiaddr::Protocol,
+    ping::Behaviour as Ping,
+    relay,
+    swarm::behaviour::toggle::Toggle,
+    swarm::NetworkBehaviour,
 };
 use libp2p_identity::Keypair;
 use recon::{libp2p::Recon, Sha256a};
@@ -265,17 +264,6 @@ where
             kad.bootstrap()?;
         }
         Ok(())
-    }
-    pub fn discover_ceramic_peers(&mut self, key: &RecordKey) -> Option<QueryId> {
-        info!(?key, "discovering Ceramic peers");
-        if let Some(kad) = self.kad.as_mut() {
-            if let Err(err) = kad.start_providing(key.clone()) {
-                warn!(%err,"failed to start providing ceramic peers key");
-            }
-            Some(kad.get_providers(key.clone()))
-        } else {
-            None
-        }
     }
 }
 


### PR DESCRIPTION
We are seeing issue related to Kademlia and seem to be connected to Ceramic peer discovery. As this feature is not needed currently, its being removed to eliminate any compounding variables. Once its needed (when we remove gossipsub) it can be reintroduced and fully tested against our established baseline.